### PR TITLE
feat: support update partial with Optimistic Concurrency Control

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.8</version>
+    <version>0.5.9</version>
     <name>${project.groupId}:${project.artifactId}$</name>
     <description>A lightweight Azure CosmosDB client for Java</description>
     <url>https://github.com/thunderz99/java-cosmos</url>

--- a/src/main/java/io/github/thunderz99/cosmos/Cosmos.java
+++ b/src/main/java/io/github/thunderz99/cosmos/Cosmos.java
@@ -31,12 +31,14 @@ public class Cosmos {
     private static Logger log = LoggerFactory.getLogger(Cosmos.class);
 
     DocumentClient client;
-    
+
     String account;
 
     static Pattern connectionStringPattern = Pattern.compile("AccountEndpoint=(?<endpoint>.+);AccountKey=(?<key>[^;]+);?");
 
     public static final String JC_SDK_V4_ENABLE = "JC_SDK_V4_ENABLE";
+
+    public static final String ETAG = "_etag";
 
     public Cosmos(String connectionString) {
         this(connectionString, null);

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosException.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosException.java
@@ -2,6 +2,9 @@ package io.github.thunderz99.cosmos;
 
 import com.microsoft.azure.documentdb.DocumentClientException;
 
+/**
+ * Original Exception thrown by java-cosmos. Wrapping v2 DocumentClientException and v4 CosmosException.
+ */
 public class CosmosException extends RuntimeException {
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/io/github/thunderz99/cosmos/dto/PartialUpdateOption.java
+++ b/src/main/java/io/github/thunderz99/cosmos/dto/PartialUpdateOption.java
@@ -1,0 +1,16 @@
+package io.github.thunderz99.cosmos.dto;
+
+/**
+ * Options when using partial update methods. e.g. whether check etags to implement a
+ */
+public class PartialUpdateOption {
+
+    public boolean checkETag = false;
+
+    public static PartialUpdateOption checkETag(boolean checkETag){
+        var option = new PartialUpdateOption();
+        option.checkETag = checkETag;
+        return option;
+    }
+
+}

--- a/src/main/java/io/github/thunderz99/cosmos/util/MapUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/MapUtil.java
@@ -12,7 +12,7 @@ public class MapUtil {
 
 
     /**
-     * get env variable as String, or return a default value.
+     * Convert a traditional java map to a "/key1/key2/key3" : value format map. Used by v4 patch method.
      *
      * <p>
      * {@code
@@ -33,8 +33,6 @@ public class MapUtil {
      * }
      *
      *
-     *
-     * }
      * </p>
      *
      * @param map

--- a/src/main/java/io/github/thunderz99/cosmos/util/MapUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/MapUtil.java
@@ -31,7 +31,7 @@ public class MapUtil {
      *     "/contents/name": "Tom",
      *     "/contents/age": 25
      * }
-     *
+     * }
      *
      * </p>
      *

--- a/src/main/java/io/github/thunderz99/cosmos/util/RetryUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/RetryUtil.java
@@ -1,31 +1,42 @@
 package io.github.thunderz99.cosmos.util;
 
+import java.util.Set;
 import java.util.concurrent.Callable;
 
+import com.google.common.collect.Sets;
 import com.microsoft.azure.documentdb.DocumentClientException;
 import io.github.thunderz99.cosmos.CosmosException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Deal with the 429 Reqeust rage is large problem by retry after a certain period
+ * Deal with the 429(too many requests) and 408(request timeout) error code by retry after a certain period
+ *
+ * <p>
+ * inspired by official documents: <a href="https://docs.microsoft.com/en-us/azure/cosmos-db/sql/bulk-executor-java">Perform bulk operations on Azure Cosmos DB data</a>
+ * </p>
  */
 public class RetryUtil {
 
-	private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
+    private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
 
-	RetryUtil(){
-	}
+    /**
+     * Codes should be retries. see <a href="https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb">http-status-codes-for-cosmosdb</a>
+     */
+    static final Set<Integer> codesShouldRetry = Sets.newHashSet(429, 449);
 
-	public static <T> T executeWithRetry(Callable<T> func) throws Exception {
-		//default wait time is 2s
-		return executeWithRetry(func, 2000);
-	}
+    RetryUtil() {
+    }
 
-	public static <T> T executeWithRetry(Callable<T> func, long defaultWaitTime) throws Exception {
-		var maxRetries = 10;
-		var i = 0;
-		while (true) {
+    public static <T> T executeWithRetry(Callable<T> func) throws Exception {
+        //default wait time is 2s
+        return executeWithRetry(func, 2000);
+    }
+
+    public static <T> T executeWithRetry(Callable<T> func, long defaultWaitTime) throws Exception {
+        var maxRetries = 10;
+        var i = 0;
+        while (true) {
             CosmosException cosmosException = null;
             try {
                 i++;
@@ -34,7 +45,7 @@ public class RetryUtil {
                 cosmosException = new CosmosException(dce);
             }
 
-            if (cosmosException.getStatusCode() == 429 || cosmosException.getMessage().contains("Request rate is large")) {
+            if (shouldRetry(cosmosException)) {
                 if (i > maxRetries) {
                     throw cosmosException;
                 }
@@ -42,12 +53,22 @@ public class RetryUtil {
                 if (wait == 0) {
                     wait = defaultWaitTime;
                 }
-                log.info("429 Too Many Requests. Wait:{} ms", wait);
+                log.info("Code:{}, 429 Too Many Requests / 449 Retry with. Wait:{} ms", cosmosException.getStatusCode(), wait);
                 Thread.sleep(wait);
             } else {
                 throw cosmosException;
             }
         }
-	}
+    }
+
+    /**
+     * Judge whether should retry action for this cosmos exception. Currently we will retry for 429/408
+     *
+     * @param cosmosException cosmosException
+     * @return true/false
+     */
+    public static boolean shouldRetry(CosmosException cosmosException) {
+        return codesShouldRetry.contains(cosmosException.getStatusCode()) || cosmosException.getMessage().contains("Request rate is large");
+    }
 
 }


### PR DESCRIPTION
### New features

#### feature 1, update partial supports Last-Write-Win and will not overwrite the field if 2 partial updates dealing with different fields
* https://github.com/thunderz99/java-cosmos#partial-update

#### feature 2, if you specify the mode to check etag, you can obtain the Optimistic Concurrency Control (Last write will fail)
* https://github.com/thunderz99/java-cosmos#partial-update-with-optimistic-concurrency-control-occ


### Reference

* https://docs.microsoft.com/en-us/azure/cosmos-db/sql/database-transactions-optimistic-concurrency#optimistic-concurrency-control