### PR TITLE
feat: batch operations and bulk operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ db.delete("Collection1", user1,id, "Users");
 ```
 
 ### Batch Operation
+> Note: Batch operation is transactional. The maximum number of operations is 100.
+> https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/transactional-batch?tabs=java
 ```java
 var db = new Cosmos(System.getenv("YOUR_CONNECTION_STRING")).getDatabase("Database1");
 
@@ -157,6 +159,8 @@ db.batchDelete("Collection1", List.of(user1.id), "Users");
 ```
 
 ### Bulk Operation
+> Note: Bulk operation is NOT transactional. Have no number limit in theoretically.
+> https://learn.microsoft.com/en-us/azure/cosmos-db/bulk-executor-overview
 ```java
 var db = new Cosmos(System.getenv("YOUR_CONNECTION_STRING")).getDatabase("Database1");
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,39 @@ db.upsert("Collection1", user1, "Users");
 db.delete("Collection1", user1,id, "Users");
 ```
 
+### Batch Operation
+```java
+var db = new Cosmos(System.getenv("YOUR_CONNECTION_STRING")).getDatabase("Database1");
 
+// Create
+db.batchCreate("Collection1", List.of(new User("id011", "Tom", "Banks")), "Users");
+
+// Upsert
+db.batchUpsert("Collection1", List.of(user1), "Users");
+
+// Delete
+db.batchDelete("Collection1", List.of(user1), "Users");
+// or
+db.batchDelete("Collection1", List.of(user1.id), "Users");
+
+```
+
+### Bulk Operation
+```java
+var db = new Cosmos(System.getenv("YOUR_CONNECTION_STRING")).getDatabase("Database1");
+
+// Create
+db.bulkCreate("Collection1", List.of(new User("id011", "Tom", "Banks")), "Users");
+
+// Upsert
+db.bulkUpsert("Collection1", List.of(user1), "Users");
+
+// Delete
+db.bulkDelete("Collection1", List.of(user1), "Users");
+// or
+db.bulkDelete("Collection1", List.of(user1.id), "Users");
+
+```
 
 ### Partial Update
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.23</version>
+    <version>0.5.24</version>
     <name>${project.groupId}:${project.artifactId}$</name>
     <description>A lightweight Azure CosmosDB client for Java</description>
     <url>https://github.com/thunderz99/java-cosmos</url>

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -193,7 +193,6 @@ public class CosmosDatabase {
     private static void doCheckBeforeBatch(String coll, List<?> data, String partition) {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
-        Checker.checkNotNull(data, "create data " + coll + " " + partition);
         Checker.checkNotEmpty(data, "create data " + coll + " " + partition);
 
         checkBatchMaxOperations(data);
@@ -203,7 +202,6 @@ public class CosmosDatabase {
     private static void doCheckBeforeBulk(String coll, List<?> data, String partition) {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
-        Checker.checkNotNull(data, "create data " + coll + " " + partition);
         Checker.checkNotEmpty(data, "create data " + coll + " " + partition);
 
         checkValidId(data);

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -179,7 +179,7 @@ public class CosmosDatabase {
         }).collect(Collectors.toList());
     }
 
-    private static String getId(Object object) {
+    static String getId(Object object) {
         String id;
         if (object instanceof String) {
             id = (String) object;
@@ -190,7 +190,7 @@ public class CosmosDatabase {
         return id;
     }
 
-    private static void doCheckBeforeBatch(String coll, List<?> data, String partition) {
+    static void doCheckBeforeBatch(String coll, List<?> data, String partition) {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
         Checker.checkNotEmpty(data, "create data " + coll + " " + partition);
@@ -199,7 +199,7 @@ public class CosmosDatabase {
         checkValidId(data);
     }
 
-    private static void doCheckBeforeBulk(String coll, List<?> data, String partition) {
+    static void doCheckBeforeBulk(String coll, List<?> data, String partition) {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
         Checker.checkNotEmpty(data, "create data " + coll + " " + partition);

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -348,6 +348,7 @@ public class CosmosDatabase {
             }
 
             if (retryTasks.isEmpty()) {
+                operations.clear();
                 break;
             } else {
                 operations = retryTasks;

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -108,7 +108,7 @@ public class CosmosDatabase {
      * @throws Exception CosmosException
      */
     public List<CosmosDocument> batchCreate(String coll, List<?> data, String partition) throws Exception {
-        doCheckBeforeBatchOrBulk(coll, data, partition);
+        doCheckBeforeBatch(coll, data, partition);
 
         var partitionKey = new com.azure.cosmos.models.PartitionKey(partition);
         var container = this.clientV4.getDatabase(db).getContainer(coll);
@@ -133,7 +133,7 @@ public class CosmosDatabase {
      * @throws Exception CosmosException
      */
     public List<CosmosDocument> batchUpsert(String coll, List<?> data, String partition) throws Exception {
-        doCheckBeforeBatchOrBulk(coll, data, partition);
+        doCheckBeforeBatch(coll, data, partition);
 
         var partitionKey = new com.azure.cosmos.models.PartitionKey(partition);
         var container = this.clientV4.getDatabase(db).getContainer(coll);
@@ -158,7 +158,7 @@ public class CosmosDatabase {
      * @throws Exception CosmosException
      */
     public List<CosmosDocument> batchDelete(String coll, List<?> data, String partition) throws Exception {
-        doCheckBeforeBatchOrBulk(coll, data, partition);
+        doCheckBeforeBatch(coll, data, partition);
 
         var partitionKey = new com.azure.cosmos.models.PartitionKey(partition);
         var container = this.clientV4.getDatabase(db).getContainer(coll);
@@ -189,12 +189,20 @@ public class CosmosDatabase {
         return id;
     }
 
-    private static void doCheckBeforeBatchOrBulk(String coll, List<?> data, String partition) {
+    private static void doCheckBeforeBatch(String coll, List<?> data, String partition) {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
         Checker.checkNotNull(data, "create data " + coll + " " + partition);
 
         checkBatchMaxOperations(data);
+        checkValidId(data);
+    }
+
+    private static void doCheckBeforeBulk(String coll, List<?> data, String partition) {
+        Checker.checkNotBlank(coll, "coll");
+        Checker.checkNotBlank(partition, "partition");
+        Checker.checkNotNull(data, "create data " + coll + " " + partition);
+
         checkValidId(data);
     }
 
@@ -222,7 +230,7 @@ public class CosmosDatabase {
      * @return CosmosBulkResult
      */
     public CosmosBulkResult bulkCreate(String coll, List<?> data, String partition) {
-        doCheckBeforeBatchOrBulk(coll, data, partition);
+        doCheckBeforeBulk(coll, data, partition);
 
         var partitionKey = new com.azure.cosmos.models.PartitionKey(partition);
         var operations = data.stream().map(it -> {
@@ -245,7 +253,7 @@ public class CosmosDatabase {
      * @return CosmosBulkResult
      */
     public CosmosBulkResult bulkUpsert(String coll, List<?> data, String partition) {
-        doCheckBeforeBatchOrBulk(coll, data, partition);
+        doCheckBeforeBulk(coll, data, partition);
 
         var partitionKey = new com.azure.cosmos.models.PartitionKey(partition);
         var operations = data.stream().map(it -> {
@@ -268,7 +276,7 @@ public class CosmosDatabase {
      * @return CosmosBulkResult
      */
     public CosmosBulkResult bulkDelete(String coll, List<?> data, String partition) {
-        doCheckBeforeBatchOrBulk(coll, data, partition);
+        doCheckBeforeBulk(coll, data, partition);
 
         var ids = new ArrayList<String>();
         var partitionKey = new com.azure.cosmos.models.PartitionKey(partition);

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -16,7 +16,6 @@ import io.github.thunderz99.cosmos.util.JsonUtil;
 import io.github.thunderz99.cosmos.util.RetryUtil;
 import io.github.thunderz99.cosmos.v4.PatchOperations;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -40,6 +39,8 @@ import static io.github.thunderz99.cosmos.condition.Condition.getFormattedKey;
 public class CosmosDatabase {
 
     private static Logger log = LoggerFactory.getLogger(CosmosDatabase.class);
+
+    static final int MAX_BATCH_NUMBER_OF_OPERATION = 100;
 
     String db;
 
@@ -193,6 +194,7 @@ public class CosmosDatabase {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
         Checker.checkNotNull(data, "create data " + coll + " " + partition);
+        Checker.checkNotEmpty(data, "create data " + coll + " " + partition);
 
         checkBatchMaxOperations(data);
         checkValidId(data);
@@ -202,6 +204,7 @@ public class CosmosDatabase {
         Checker.checkNotBlank(coll, "coll");
         Checker.checkNotBlank(partition, "partition");
         Checker.checkNotNull(data, "create data " + coll + " " + partition);
+        Checker.checkNotEmpty(data, "create data " + coll + " " + partition);
 
         checkValidId(data);
     }
@@ -369,7 +372,7 @@ public class CosmosDatabase {
     static void checkBatchMaxOperations(List<?> data) {
         // There's a current limit of 100 operations per TransactionalBatch to ensure the performance is as expected and within SLAs:
         // https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/transactional-batch?tabs=dotnet#limitations
-        if (data.size() > 100) {
+        if (data.size() > MAX_BATCH_NUMBER_OF_OPERATION) {
             throw new IllegalArgumentException("The number of data operations should not exceed 100.");
         }
     }

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -337,12 +337,12 @@ public class CosmosDatabase {
                     var ex = result.getException();
                     if (HttpStatus.SC_CONFLICT == response.getStatusCode()) {
                         Map<String, String> map = operation.getItem();
-                        bulkResult.fetalList.add(new CosmosException(response.getStatusCode(), "CONFLICT", "id already exits: " + map.get("id")));
+                        bulkResult.fatalList.add(new CosmosException(response.getStatusCode(), "CONFLICT", "id already exits: " + map.get("id")));
                     } else {
                         if (ObjectUtils.isNotEmpty(ex)) {
-                            bulkResult.fetalList.add(new CosmosException(response.getStatusCode(), ex.getMessage(), ex.getMessage()));
+                            bulkResult.fatalList.add(new CosmosException(response.getStatusCode(), ex.getMessage(), ex.getMessage()));
                         } else {
-                            bulkResult.fetalList.add(new CosmosException(response.getStatusCode(), "UNKNOWN", "UNKNOWN"));
+                            bulkResult.fatalList.add(new CosmosException(response.getStatusCode(), "UNKNOWN", "UNKNOWN"));
                         }
                     }
                 }

--- a/src/main/java/io/github/thunderz99/cosmos/dto/CosmosBulkResult.java
+++ b/src/main/java/io/github/thunderz99/cosmos/dto/CosmosBulkResult.java
@@ -1,0 +1,28 @@
+package io.github.thunderz99.cosmos.dto;
+
+import io.github.thunderz99.cosmos.CosmosDocument;
+import io.github.thunderz99.cosmos.CosmosException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The result of bulk operations
+ */
+public class CosmosBulkResult {
+
+    /**
+     * The result of success operations
+     */
+    public List<CosmosDocument> successList = new ArrayList<>();
+
+    /**
+     * The result of retries operations that exceed the max retry times
+     */
+    public List<?> retryList = new ArrayList<>();
+
+    /**
+     * The result of fetal operations. e.g. 409 Conflict
+     */
+    public List<CosmosException> fetalList = new ArrayList<>();
+}

--- a/src/main/java/io/github/thunderz99/cosmos/dto/CosmosBulkResult.java
+++ b/src/main/java/io/github/thunderz99/cosmos/dto/CosmosBulkResult.java
@@ -22,7 +22,7 @@ public class CosmosBulkResult {
     public List<?> retryList = new ArrayList<>();
 
     /**
-     * The result of fetal operations. e.g. 409 Conflict
+     * The result of fatal operations. e.g. 409 Conflict
      */
-    public List<CosmosException> fetalList = new ArrayList<>();
+    public List<CosmosException> fatalList = new ArrayList<>();
 }

--- a/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
@@ -41,13 +41,10 @@ public class Checker {
 
 	}
 
-    public static void checkNotEmpty(Object target, String name) {
+    public static void checkNotEmpty(Collection target, String name) {
 
-        if (target instanceof Collection) {
-            var collection = (Collection<?>) target;
-            if (collection.isEmpty()) {
-                throw new IllegalArgumentException(String.format("%s should not be empty collection", name));
-            }
+        if (target.isEmpty()) {
+            throw new IllegalArgumentException(String.format("%s should not be empty collection", name));
         }
 
     }

--- a/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
@@ -23,13 +23,6 @@ public class Checker {
 			throw new IllegalArgumentException(String.format("%s should not be null", name));
 		}
 
-        if (target instanceof Collection) {
-            var collection = (Collection<?>) target;
-            if (collection.isEmpty()) {
-                throw new IllegalArgumentException(String.format("%s should not be empty", name));
-            }
-        }
-
 	}
 
 	public static void checkNotBlank(String target, String name) {
@@ -47,4 +40,15 @@ public class Checker {
 		}
 
 	}
+
+    public static void checkNotEmpty(Object target, String name) {
+
+        if (target instanceof Collection) {
+            var collection = (Collection<?>) target;
+            if (collection.isEmpty()) {
+                throw new IllegalArgumentException(String.format("%s should not be empty collection", name));
+            }
+        }
+
+    }
 }

--- a/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
@@ -41,9 +41,9 @@ public class Checker {
 
 	}
 
-    public static void checkNotEmpty(Collection target, String name) {
+    public static void checkNotEmpty(Collection<?> target, String name) {
 
-        if (target.isEmpty()) {
+        if (target == null || target.isEmpty()) {
             throw new IllegalArgumentException(String.format("%s should not be empty collection", name));
         }
 

--- a/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/Checker.java
@@ -2,6 +2,8 @@ package io.github.thunderz99.cosmos.util;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collection;
+
 public class Checker {
 
 	Checker(){
@@ -20,6 +22,13 @@ public class Checker {
 		if (target == null) {
 			throw new IllegalArgumentException(String.format("%s should not be null", name));
 		}
+
+        if (target instanceof Collection) {
+            var collection = (Collection<?>) target;
+            if (collection.isEmpty()) {
+                throw new IllegalArgumentException(String.format("%s should not be empty", name));
+            }
+        }
 
 	}
 

--- a/src/test/java/io/github/thunderz99/cosmos/CosmosDatabaseTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/CosmosDatabaseTest.java
@@ -134,7 +134,7 @@ class CosmosDatabaseTest {
 
     @Test
     void bulkCreate_should_work() throws Exception {
-        int size = 100;
+        int size = 120;
         var userList = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             userList.add(new User("bulkCreate_should_work_" + i, "testFirstName" + i, "testLastName" + i));
@@ -146,13 +146,13 @@ class CosmosDatabaseTest {
             assertThat(result.retryList).hasSize(0);
             assertThat(result.successList).hasSize(size);
         } finally {
-            db.bulkCreate(coll, userList, "Users");
+            db.bulkDelete(coll, userList, "Users");
         }
     }
 
     @Test
     void bulkDelete_should_work() throws Exception {
-        int size = 100;
+        int size = 120;
         var userList = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             userList.add(new User("bulkDelete_should_work_" + i, "testFirstName" + i, "testLastName" + i));

--- a/src/test/java/io/github/thunderz99/cosmos/CosmosDatabaseTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/CosmosDatabaseTest.java
@@ -142,7 +142,7 @@ class CosmosDatabaseTest {
 
         try {
             var result = db.bulkCreate(coll, userList, "Users");
-            assertThat(result.fetalList).hasSize(0);
+            assertThat(result.fatalList).hasSize(0);
             assertThat(result.retryList).hasSize(0);
             assertThat(result.successList).hasSize(size);
         } finally {
@@ -161,7 +161,7 @@ class CosmosDatabaseTest {
         try {
             db.bulkCreate(coll, userList, "Users");
             var deleteResult = db.bulkDelete(coll, userList, "Users");
-            assertThat(deleteResult.fetalList).hasSize(0);
+            assertThat(deleteResult.fatalList).hasSize(0);
             assertThat(deleteResult.retryList).hasSize(0);
             assertThat(deleteResult.successList).hasSize(size);
         } finally {
@@ -181,7 +181,7 @@ class CosmosDatabaseTest {
 
         try {
             var createResult = db.bulkCreate(coll, userList, "Users");
-            assertThat(createResult.fetalList).hasSize(0);
+            assertThat(createResult.fatalList).hasSize(0);
             assertThat(createResult.retryList).hasSize(0);
             assertThat(createResult.successList).hasSize(size);
 
@@ -193,7 +193,7 @@ class CosmosDatabaseTest {
             }
 
             var upsertResult = db.bulkUpsert(coll, upsertList, "Users");
-            assertThat(upsertResult.fetalList).hasSize(0);
+            assertThat(upsertResult.fatalList).hasSize(0);
             assertThat(upsertResult.retryList).hasSize(0);
             assertThat(upsertResult.successList).hasSize(size);
 

--- a/src/test/java/io/github/thunderz99/cosmos/CosmosDatabaseTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/CosmosDatabaseTest.java
@@ -228,6 +228,183 @@ class CosmosDatabaseTest {
 
 	}
 
+    @Test
+    void getId_should_work() {
+        String testId = "getId_should_work_id";
+        var user = new User(testId, "firstName", "lastName");
+        var id = CosmosDatabase.getId(user);
+        assertThat(id).isEqualTo(testId);
+
+        id = CosmosDatabase.getId(testId);
+        assertThat(id).isEqualTo(testId);
+    }
+
+    @Test
+    void doCheckBeforeBatch_should_work() {
+        // normal check
+        {
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+            List<User> testData = List.of(new User("doCheckBeforeBatch_should_work_id", "first01", "last01"));
+
+            CosmosDatabase.doCheckBeforeBatch(testColl, testData, testPartition);
+        }
+
+        // boundary checks
+        {
+            // blank coll should raise exception
+            String testColl = "";
+            String testPartition = "testPartition";
+            List<User> testData = List.of(new User("doCheckBeforeBatch_should_work_id", "first01", "last01"));
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBatch(testColl, testData, testPartition)).hasMessageContaining("coll should be non-blank");
+        }
+
+        {
+            // blank partition should raise exception
+            String testColl = "testColl";
+            String testPartition = "";
+            List<User> testData = List.of(new User("doCheckBeforeBatch_should_work_id", "first01", "last01"));
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBatch(testColl, testData, testPartition)).hasMessageContaining("partition should be non-blank");
+        }
+
+        {
+            // empty data should raise exception
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBatch(testColl, List.of(), testPartition)).hasMessageContaining("should not be empty collection");
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBatch(testColl, null, testPartition)).hasMessageContaining("should not be empty collection");
+        }
+
+        {
+            // number of operations exceed the limit should raise exception
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 101; i++) {
+                testData.add(new User());
+            }
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBatch(testColl, testData, testPartition)).hasMessageContaining("The number of data operations should not exceed 100.");
+        }
+
+        {
+            // invalid id should raise exception
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add(new User("invalid_id\n", "", ""));
+            }
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBatch(testColl, testData, testPartition)).hasMessageContaining("id cannot contain \\t or \\n or \\r.");
+        }
+    }
+
+    @Test
+    void doCheckBeforeBulk_should_work() {
+        // normal check
+        {
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+            List<User> testData = List.of(new User("doCheckBeforeBulk_should_work_id", "first01", "last01"));
+
+            CosmosDatabase.doCheckBeforeBulk(testColl, testData, testPartition);
+        }
+
+        // boundary checks
+        {
+            // blank coll should raise exception
+            String testColl = "";
+            String testPartition = "testPartition";
+            List<User> testData = List.of(new User("doCheckBeforeBulk_should_work_id", "first01", "last01"));
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBulk(testColl, testData, testPartition)).hasMessageContaining("coll should be non-blank");
+        }
+
+        {
+            // blank partition should raise exception
+            String testColl = "testColl";
+            String testPartition = "";
+            List<User> testData = List.of(new User("doCheckBeforeBulk_should_work_id", "first01", "last01"));
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBulk(testColl, testData, testPartition)).hasMessageContaining("partition should be non-blank");
+        }
+
+        {
+            // empty data should raise exception
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBulk(testColl, List.of(), testPartition)).hasMessageContaining("should not be empty collection");
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBulk(testColl, null, testPartition)).hasMessageContaining("should not be empty collection");
+        }
+
+        {
+            // invalid id should raise exception
+            String testColl = "testColl";
+            String testPartition = "testPartition";
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add(new User("invalid_id\n", "", ""));
+            }
+
+            assertThatThrownBy(() -> CosmosDatabase.doCheckBeforeBulk(testColl, testData, testPartition)).hasMessageContaining("id cannot contain \\t or \\n or \\r.");
+        }
+    }
+
+    @Test
+    void checkValidId_should_work() {
+        // normal check
+        {
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add(new User("valid_id", "", ""));
+            }
+
+            CosmosDatabase.checkValidId(testData);
+        }
+
+        {
+            List<String> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add("valid_id");
+            }
+
+            CosmosDatabase.checkValidId(testData);
+        }
+
+        // boundary checks
+        {
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add(new User("invalid_id\t", "", ""));
+            }
+
+            assertThatThrownBy(() -> CosmosDatabase.checkValidId(testData)).hasMessageContaining("id cannot contain \\t or \\n or \\r.");
+        }
+
+        {
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add(new User("invalid_id\n", "", ""));
+            }
+
+            assertThatThrownBy(() -> CosmosDatabase.checkValidId(testData)).hasMessageContaining("id cannot contain \\t or \\n or \\r.");
+        }
+
+        {
+            List<User> testData = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                testData.add(new User("invalid_id\r", "", ""));
+            }
+
+            assertThatThrownBy(() -> CosmosDatabase.checkValidId(testData)).hasMessageContaining("id cannot contain \\t or \\n or \\r.");
+        }
+    }
+
 	@Test
 	void create_should_throw_when_data_is_null() throws Exception {
 		User user = null;


### PR DESCRIPTION
Add methods for supporting bulk operations and batch operations.

- batchCreate
- batchUpsert
- batchDelete
- bulkCreate
- bulkUpsert
- bulkDelete

Note: batch is transactional and bulk is not transactional.