### PR TITLE
feat: update to azure cosmos sdk v4(step1: CRUD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ java-cosmos is a client for Azure CosmosDB 's SQL API (also called documentdb fo
 <dependency>
   <groupId>com.github.thunderz99</groupId>
   <artifactId>java-cosmos</artifactId>
-  <version>0.5.20</version>
+  <version>0.6.1</version>
 </dependency>
 ```
 
@@ -403,3 +403,8 @@ The main difference between Partial update and Patch is that:
     var users = db.find("Collection1", cond).toList(User.class);
 ```
 
+
+## Reference
+
+This library is built based on the official Azure Cosmos DB Java SDK v4.
+https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/sdk-java-v4

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# install the jar file to local repositories
+mvn clean install -s settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.24</version>
+    <version>0.6.1</version>
     <name>${project.groupId}:${project.artifactId}$</name>
     <description>A lightweight Azure CosmosDB client for Java</description>
     <url>https://github.com/thunderz99/java-cosmos</url>
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-cosmos</artifactId>
-            <version>4.31.0</version>
+            <version>4.56.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosException.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosException.java
@@ -52,7 +52,6 @@ public class CosmosException extends RuntimeException {
         // can not get CosmosException's code yet.
         this.code = "";
         this.retryAfterInMilliseconds = ce.getRetryAfterDuration().toMillis();
-
     }
 
     /**

--- a/src/main/java/io/github/thunderz99/cosmos/util/RetryUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/RetryUtil.java
@@ -43,8 +43,11 @@ public class RetryUtil {
                 return response;
             } else if (shouldRetry(response.getStatusCode())) {
                 long delay = response.getRetryAfterDuration().toMillis();
-                if (delay == 0) {
+                if (delay <= 0) {
                     delay = defaultWaitTime;
+                    if (delay < 0) {
+                        log.warn("retryAfterInMilliseconds {} is minus. Will retry by defaultWaitTime(2000ms). error:{}", delay, response.getErrorMessage());
+                    }
                 }
                 try {
                     log.info("Code:{}, 429 Too Many Requests / 449 Retry with / 408 Request Timeout. Wait:{} ms", response.getStatusCode(), delay);
@@ -87,8 +90,12 @@ public class RetryUtil {
                     throw cosmosException;
                 }
                 var wait = cosmosException.getRetryAfterInMilliseconds();
-                if (wait == 0) {
+                if (wait <= 0) {
                     wait = defaultWaitTime;
+
+                    if (wait < 0) {
+                        log.warn("retryAfterInMilliseconds {} is minus. Will retry by defaultWaitTime(2000ms)", wait, cosmosException);
+                    }
                 }
                 log.info("Code:{}, 429 Too Many Requests / 449 Retry with / 408 Request Timeout. Wait:{} ms", cosmosException.getStatusCode(), wait);
                 Thread.sleep(wait);

--- a/src/test/java/io/github/thunderz99/cosmos/condition/ConditionTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/condition/ConditionTest.java
@@ -206,11 +206,11 @@ class ConditionTest {
         {
             //multiple SUB_COND_OR s
             var q = Condition.filter(
-                    SubConditionType.OR,
-                    Condition.filter("position", "leader"),
-                    SubConditionType.OR + " 2",
-                    Condition.filter("address", "London")
-            )
+                            SubConditionType.OR,
+                            Condition.filter("position", "leader"),
+                            SubConditionType.OR + " 2",
+                            Condition.filter("address", "London")
+                    )
                     .toQuerySpec();
             assertThat(q.getQueryText()).isEqualTo("SELECT * FROM c WHERE ((c[\"position\"] = @param000_position)) AND ((c[\"address\"] = @param001_address)) OFFSET 0 LIMIT 100");
             var params = List.copyOf(q.getParameters());
@@ -219,13 +219,26 @@ class ConditionTest {
         }
     }
 
-	@Test
-	public void buildQuerySpec_should_work_for_sub_cond_or_from_the_beginning() {
+    @Test
+    public void buildQuerySpec_should_work_for_and_nested_with_or() {
+
+        var q = Condition.filter("isChecked", true,
+                        "$OR or_first ",
+                        List.of(Condition.filter("id_A", "value_A"),
+                                Condition.filter("id_B", "value_B", "id_C", "value_C")))
+                .toQuerySpec();
+
+
+        assertThat(q.getQueryText()).isEqualTo("SELECT * FROM c WHERE (c[\"isChecked\"] = @param000_isChecked) AND ((c[\"id_A\"] = @param001_id_A) OR (c[\"id_B\"] = @param002_id_B) AND (c[\"id_C\"] = @param003_id_C)) OFFSET 0 LIMIT 100");
+    }
+
+    @Test
+    public void buildQuerySpec_should_work_for_sub_cond_or_from_the_beginning() {
 
         var q = Condition.filter( //
-                SubConditionType.OR,
-                List.of(Condition.filter("position", "leader"), Condition.filter("organization", "executive")) //
-        ) //
+                        SubConditionType.OR,
+                        List.of(Condition.filter("position", "leader"), Condition.filter("organization", "executive")) //
+                ) //
                 .sort("_ts", "DESC") //
                 .offset(10) //
                 .limit(20) //

--- a/src/test/java/io/github/thunderz99/cosmos/util/RetryUtilTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/util/RetryUtilTest.java
@@ -104,4 +104,23 @@ class RetryUtilTest {
         });
 
     }
+
+    @Test
+    void executeWithRetry_should_work_when_delay_time_is_minus() throws Exception {
+
+        { // even is delay time < 0, we will work as default delay time, and do not throw exception.
+            final var i = new AtomicInteger(0);
+
+            // success within 3 second(because default wait time is 2000 ms)
+            var ret = assertTimeout(ofSeconds(3), () ->
+                    RetryUtil.executeWithRetry(() -> {
+                        if (i.incrementAndGet() < 2) {
+                            throw new DocumentClientException(429, new com.microsoft.azure.documentdb.Error("{}"), Map.of(RETRY_AFTER_IN_MILLISECONDS, "-1"));
+                        }
+                        return "OK";
+                    })
+            );
+            assertThat(ret).isEqualTo("OK");
+        }
+    }
 }

--- a/src/test/resources/io/github/thunderz99/cosmos/sheet-integer.json
+++ b/src/test/resources/io/github/thunderz99/cosmos/sheet-integer.json
@@ -1,0 +1,51 @@
+
+{
+  "id": "sheet-integer01",
+  "contents": {
+    "SingleLineText001" : {
+      "itemId" : "SingleLineText001",
+      "type" : "SingleLineText",
+      "value" : "ss",
+      "show" : true,
+      "required" : false,
+      "empty" : false,
+      "userEdited" : true
+    },
+    "Date003" : {
+      "itemId" : "Date003",
+      "type" : "Date",
+      "value" : "2019-09-09",
+      "show" : true,
+      "required" : false,
+      "empty" : false,
+      "userEdited" : true
+    },
+    "Decimal002" : {
+      "itemId" : "Decimal002",
+      "type" : "Decimal",
+      "value" : 3,
+      "show" : true,
+      "required" : false,
+      "empty" : false,
+      "userEdited" : true
+    },
+    "SingleLineText004" : {
+      "itemId" : "SingleLineText004",
+      "type" : "SingleLineText",
+      "value" : "fff3",
+      "show" : true,
+      "required" : false,
+      "empty" : false,
+      "userEdited" : true
+    },
+    "MultipleLineText005" : {
+      "itemId" : "MultipleLineText005",
+      "type" : "MultipleLineText",
+      "value" : "dfdf",
+      "show" : true,
+      "required" : false,
+      "empty" : false,
+      "userEdited" : true
+    }
+  }
+}


### PR DESCRIPTION
## Backgroud

v2 is deprecated by Azure.

https://azure.github.io/azure-sdk/releases/deprecated/java.html
https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/migrate-java-v4-sdk?tabs=java-v4-async

## Before

* CRUD : v2
* query : v2
* database operations: v2
* container operations: v2
* patch(JSON Patch) : v4
* batch operations : v4
* bulk operations : v4

## After

* CRUD : v4
* query : v2
* database operations: v2
* container operations: v2
* patch(JSON Patch) : v4
* batch operations : v4
* bulk operations : v4

## TODO

* query will be done at step2 (0.6.2)
* db / container operations will be done at step3(0.6.3)
