### PR TITLE
fix: CosmosException's statusCode not correct when 429 in batchExecute

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ java-cosmos is a client for Azure CosmosDB 's SQL API (also called documentdb fo
 <dependency>
   <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
     <packaging>jar</packaging>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <name>${project.groupId}:${project.artifactId}$</name>
     <description>A lightweight Azure CosmosDB client for Java</description>
     <url>https://github.com/thunderz99/java-cosmos</url>

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -10,6 +10,7 @@ import com.azure.cosmos.models.*;
 import com.google.common.base.Preconditions;
 import io.github.thunderz99.cosmos.condition.Aggregate;
 import io.github.thunderz99.cosmos.condition.Condition;
+import io.github.thunderz99.cosmos.dto.CosmosBatchResponseWrapper;
 import io.github.thunderz99.cosmos.dto.CosmosBulkResult;
 import io.github.thunderz99.cosmos.dto.CosmosSqlQuerySpec;
 import io.github.thunderz99.cosmos.dto.PartialUpdateOption;
@@ -207,10 +208,12 @@ public class CosmosDatabase {
     }
 
     private List<CosmosDocument> doBatchWithRetry(CosmosContainer container, CosmosBatch batch) throws Exception {
-        var response = RetryUtil.executeBatchWithRetry(() -> container.executeCosmosBatch(batch));
+        var response = RetryUtil.executeBatchWithRetry(() ->
+                new CosmosBatchResponseWrapper(container.executeCosmosBatch(batch))
+        );
 
         var successDocuments = new ArrayList<CosmosDocument>();
-        for (CosmosBatchOperationResult cosmosBatchOperationResult : response.getResults()) {
+        for (CosmosBatchOperationResult cosmosBatchOperationResult : response.cosmosBatchReponse.getResults()) {
             var item = cosmosBatchOperationResult.getItem(mapInstance.getClass());
             if (item == null) continue;
             successDocuments.add(new CosmosDocument(item));

--- a/src/main/java/io/github/thunderz99/cosmos/dto/CosmosBatchResponseWrapper.java
+++ b/src/main/java/io/github/thunderz99/cosmos/dto/CosmosBatchResponseWrapper.java
@@ -1,0 +1,101 @@
+package io.github.thunderz99.cosmos.dto;
+
+import java.time.Duration;
+
+import com.azure.cosmos.models.CosmosBatchResponse;
+
+/**
+ * A dto class representing the batch result of CosmosDB.
+ *
+ * <p>
+ *     We use this wrapper object to overcame the problem that we cannot new an original CosmosBatchReponse to test
+ * </p>
+ */
+public class CosmosBatchResponseWrapper {
+
+    public CosmosBatchResponseWrapper(){
+    }
+
+    public CosmosBatchResponseWrapper(CosmosBatchResponse response){
+        this.cosmosBatchReponse = response;
+    }
+
+    public CosmosBatchResponseWrapper(int statusCode, int subStatusCode, String errorMessage){
+        this.statusCode = statusCode;
+        this.subStatusCode = subStatusCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public CosmosBatchResponseWrapper(int statusCode, int subStatusCode, String errorMessage, Duration duration){
+        this.statusCode = statusCode;
+        this.subStatusCode = subStatusCode;
+        this.errorMessage = errorMessage;
+        this.duration = duration;
+    }
+
+
+    public CosmosBatchResponse cosmosBatchReponse;
+
+    public int statusCode = 0;
+
+    public int subStatusCode = 0;
+
+    public String errorMessage = "";
+
+    public Duration duration = Duration.ZERO;
+
+    /**
+     * Get the statusCode from cosmosBatchReponse
+     * @return statusCode
+     */
+    public int getStatusCode() {
+        if(cosmosBatchReponse != null){
+            return cosmosBatchReponse.getStatusCode();
+        }
+        return statusCode;
+    }
+
+    /**
+     * Get the subStatusCode from cosmosBatchReponse
+     * @return subStatusCode
+     */
+    public int getSubStatusCode() {
+        if(cosmosBatchReponse != null){
+            return cosmosBatchReponse.getSubStatusCode();
+        }
+        return subStatusCode;
+    }
+
+    /**
+     * Get the subStatusCode from cosmosBatchReponse
+     * @return subStatusCode
+     */
+    public String getErrorMessage() {
+        if(cosmosBatchReponse != null){
+            return cosmosBatchReponse.getErrorMessage();
+        }
+        return errorMessage;
+    }
+
+    /**
+     * Get whether statusCode is successful
+     * @return isSuccessStatusCode
+     */
+    public boolean isSuccessStatusCode() {
+        if(cosmosBatchReponse != null){
+            return cosmosBatchReponse.isSuccessStatusCode();
+        }
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    /**
+     * Get the retryAfterDuration
+     * @return retryAfterDuration
+     */
+    public Duration getRetryAfterDuration() {
+        if(cosmosBatchReponse != null){
+            return cosmosBatchReponse.getRetryAfterDuration();
+        }
+        return duration;
+    }
+}


### PR DESCRIPTION
### Current
When `batchExecute` fails 10 times due to a 429 status code, a `CosmosException` with status code 0 will be thrown. This makes it difficult for programs calling `batchExecute` to catch this exception and correctly identify the status code.

### Expectation
A `CosmosException` with status code 429 (the same as the root cause's status code) should be thrown. This way, the caller can catch the exception and obtain a reasonable status code for further processing.

### Way to Fix
Modify the status code of the thrown `CosmosException` and add a corresponding unit test.
