### PR TITLE
fix: improve aggregate for postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
     <packaging>jar</packaging>
-    <version>0.8.3</version>
+    <version>0.8.4</version>
     <name>${project.groupId}:${project.artifactId}$</name>
     <description>A lightweight Azure CosmosDB client for Java</description>
     <url>https://github.com/thunderz99/java-cosmos</url>

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/condition/PGSubQueryExpression4Join.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/condition/PGSubQueryExpression4Join.java
@@ -153,7 +153,7 @@ public class PGSubQueryExpression4Join implements Expression {
         // var filterKey = filterKey;
         // var paramIndex = paramIndex
         var subExp4Select = new PGSubQueryExpression(remainedJoinKey, this.filterKey, this.value, this.operator);
-        PGSelectUtil.saveQueryInfo4Join(queryContext, baseKey, remainedJoinKey, filterKey, paramIndex, subExp4Select);
+        PGSelectUtil.saveQueryInfo4Join(queryContext, baseKey, paramIndex, subExp4Select);
 
         return ret;
 

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/dto/FilterQueryInfo4Join.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/dto/FilterQueryInfo4Join.java
@@ -23,10 +23,8 @@ public class FilterQueryInfo4Join {
     public FilterQueryInfo4Join(){
     }
 
-    public FilterQueryInfo4Join(String baseKey, String remainedJoinKey, String filterKey, AtomicInteger paramIndex, Expression subExp){
+    public FilterQueryInfo4Join(String baseKey, AtomicInteger paramIndex, Expression subExp){
         this.baseKey = baseKey;
-        this.remainedJoinKey = remainedJoinKey;
-        this.filterKey = filterKey;
         this.paramIndex = paramIndex;
         this.subExp = subExp;
     }
@@ -35,29 +33,6 @@ public class FilterQueryInfo4Join {
      * baseKey for join. e.g. "floors"
      */
     public String baseKey;
-
-
-    /**
-     * remainedJoinKey for join. e.g. "rooms"  ("floors.rooms" whose baseKey part is removed)
-     */
-    public String remainedJoinKey;
-
-    /**
-     * filterKey for ARRAY_CONTAINS_ANY or ARRAY_CONTAINS_ALL
-     * could be empty.
-     * e.g. "name".
-     *
-     * <p>
-     * {@code
-     *   // in this case
-     *   // baseKey = "floors"
-     *   // remainedJoinKey = "rooms"
-     *   // filterKey = "name"
-     *   Condition.filter"floors.rooms ARRAY_CONTAINS_ANY name", List.of("r1", "r2")).join(Set.of("floors"))
-     * }
-     * </p>
-     */
-    public String filterKey;
 
     /**
      * the numbering for param000, param001, param002 and so on.

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/dto/QueryContext.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/dto/QueryContext.java
@@ -4,8 +4,9 @@ import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import io.github.thunderz99.cosmos.dto.CosmosSqlParameter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.github.thunderz99.cosmos.dto.RecordData;
+import io.github.thunderz99.cosmos.impl.postgres.PostgresDatabaseImpl;
 
 /**
  * context info for query, especially when join and (returnAllSubArray=false) is used.
@@ -15,26 +16,6 @@ import io.github.thunderz99.cosmos.dto.RecordData;
  * </p>
  */
 public class QueryContext extends RecordData {
-
-
-    /**
-     * Deprecated. use filterQueryInfos4Join instead. which is better at returnAllSubArray=false
-     * Save the query key and params so that we can reuse these in the SELECT clause when join is used and returnAllSubArray = false.
-     *
-     * <p>
-     * {@code
-     *   {
-     *     "floors.rooms":[
-     *        "floor.rooms.name": {"name": "@param000_floors_rooms_name", "value": "$.floors[*].rooms[*] ? (@.name == \"r1\" || @.name == \"r2\")"},
-     *        "floors.rooms.no": {"name": "@param001_floors_rooms_no", "value": "$.floors[*].rooms[*] ? (@.no > 10)"}
-     *      ]
-     *   }
-     * }
-     * </p>
-     */
-    @Deprecated
-    public Map<String, List<Map<String, CosmosSqlParameter>>> subQueries = new LinkedHashMap<>();
-
 
     /**
      * {@code
@@ -84,6 +65,23 @@ public class QueryContext extends RecordData {
      */
     public boolean afterAggregation = false;
 
+    public String schemaName;
+
+    public String tableName;
+
+    /**
+     * databaseImpl to be set in the context
+     *
+     * <p>
+     *     when doing aggregate query, we need to use the databaseImpl to determine the type of the min/max target field
+     * </p>
+     * <p>
+     *     this field is not a simple data dto. so it should not be serialized
+     * </p>
+     */
+    @JsonIgnore
+    public PostgresDatabaseImpl databaseImpl;
+
     /**
      * Factory method
      * @return new FilterOptions
@@ -102,5 +100,17 @@ public class QueryContext extends RecordData {
         this.afterAggregation = afterAggregation;
         return this;
     }
+
+    /**
+     * set the databaseImpl context
+     * @param databaseImpl
+     * @return self
+     */
+    public QueryContext databaseImpl(PostgresDatabaseImpl databaseImpl){
+        this.databaseImpl = databaseImpl;
+        return this;
+    }
+
+
 
 }

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/PGKeyUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/PGKeyUtil.java
@@ -160,7 +160,7 @@ public class PGKeyUtil {
             return getFormattedKeyWithAlias(key, TableUtil.DATA, "");
         }
 
-        // for others (SUM, MIN, MAX, AVG, etc.)
+        // for others (SUM, AVG, etc.)
         // return (data->>'key')::numeric
         return getFormattedKeyWithAlias(key, TableUtil.DATA, 0);
 

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/PGSelectUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/PGSelectUtil.java
@@ -374,18 +374,16 @@ public class PGSelectUtil {
      *
      * @param queryContext the context to save the information
      * @param baseKey      the base key, e.g. "floors"
-     * @param remainedJoinKey the remained key, e.g. "rooms"
-     * @param filterKey   the filter key, e.g. "name"
      * @param paramIndex  the param index
      * @param subExp      the sub expression
      */
-    public static void saveQueryInfo4Join(QueryContext queryContext, String baseKey, String remainedJoinKey, String filterKey, AtomicInteger paramIndex, Expression subExp) {
+    public static void saveQueryInfo4Join(QueryContext queryContext, String baseKey, AtomicInteger paramIndex, Expression subExp) {
 
         var queryList = queryContext.filterQueryInfos4Join.get(baseKey);
         if (queryList == null) {
             queryList = new ArrayList<>();
         }
-        queryList.add(new FilterQueryInfo4Join(baseKey, remainedJoinKey, filterKey, paramIndex, subExp));
+        queryList.add(new FilterQueryInfo4Join(baseKey, paramIndex, subExp));
         queryContext.filterQueryInfos4Join.put(baseKey, queryList);
 
     }

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/TableUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/TableUtil.java
@@ -1469,7 +1469,7 @@ public class TableUtil {
         indexName = checkAndNormalizeValidEntityName(indexName);
 
         // postgres supports the "DROP INDEX IF EXISTS" syntax.
-        String sql = "DROP INDEX IF EXISTS " + schemaName + "." + indexName;
+        var sql = "DROP INDEX IF EXISTS " + schemaName + "." + indexName;
         try (var stmt = connection.createStatement()) {
             stmt.execute(sql);
             if (log.isInfoEnabled()) {

--- a/src/main/java/io/github/thunderz99/cosmos/util/NumberUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/NumberUtil.java
@@ -30,7 +30,9 @@ public class NumberUtil {
                 return floatValue.intValue(); // Convert to Integer if within range and has no fractional part.
             }
         } else if (number instanceof BigDecimal bigDecimalValue) {
-            if(bigDecimalValue.compareTo(BigDecimal.valueOf(Integer.MIN_VALUE)) >= 0 && bigDecimalValue.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) <= 0) {
+            if(bigDecimalValue.stripTrailingZeros().scale() <= 0
+                    && bigDecimalValue.compareTo(BigDecimal.valueOf(Integer.MIN_VALUE)) >= 0
+                    && bigDecimalValue.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) <= 0) {
                 return bigDecimalValue.intValue();
             }
         }

--- a/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
@@ -582,7 +582,7 @@ class CosmosDatabaseImplTest {
             var aggregate = Aggregate.function("COUNT(1) as facetCount")
                     .groupBy("_partition")
                     .conditionAfterAggregate(Condition.filter().sort("_partition", "ASC"));
-            var cond = Condition.filter("_partition", Set.of("Users", "Users2")).crossPartition(true);
+            var cond = Condition.filter("_partition", Set.of("Users", "Users2"), "id STARTSWITH", "id_find_filter").crossPartition(true);
             var result = db.aggregate(coll, aggregate, cond).toMap();
             assertThat(result).hasSize(2);
             assertThat(result.get(0).get("_partition")).isEqualTo("Users");
@@ -1441,6 +1441,7 @@ class CosmosDatabaseImplTest {
             db.delete(host, id1, partition);
             db.delete(host, id2, partition);
             db.delete(host, id3, partition);
+            db.delete(host, id4, partition);
         }
 
     }

--- a/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
@@ -2113,10 +2113,10 @@ class CosmosDatabaseImplTest {
 
             { // test returnAllSubArray(true)
                 var cond = new Condition();
-                cond = Condition.filter(
+                cond = Condition.filter(SubConditionType.ELEM_MATCH, Map.of(
                                 "children.gender", "male",
                                 "children.grade >=", 5
-                        )
+                        ))
                         .sort("lastName", "ASC") //
                         .limit(10) //
                         .offset(0)
@@ -2131,10 +2131,10 @@ class CosmosDatabaseImplTest {
             }
             { // test returnAllSubArray(false)
                 var cond = new Condition();
-                cond = Condition.filter(
+                cond = Condition.filter(SubConditionType.ELEM_MATCH,Map.of(
                                 "children.gender", "male",
                                 "children.grade >=", 5
-                        )
+                        ))
                         .sort("lastName", "ASC") //
                         .limit(10) //
                         .offset(0)

--- a/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
@@ -1371,16 +1371,26 @@ class CosmosDatabaseImplTest {
             });
         }
 
-        // test aggregate(group by "id" without count)
+        // test aggregate(aggregate using "c.id", group by "id")
         {
-            var aggregate = Aggregate.function("id AS userId").groupBy("id");
+            var aggregate = Aggregate.function("c.id AS userId").groupBy("id");
             var cond = Condition.filter("id STARTSWITH", "id_find_filter");
 
             var result = db.aggregate(host, aggregate, cond, "Users").toMap();
             assertThat(result).hasSize(3);
 
-            // we alias id as userId
-            assertThat(result.get(0).get("id")).isNull();
+            assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
+                assertThat(id).startsWith("id_find_filter");
+            });
+        }
+
+        // test aggregate(aggregate using c["id"], group by "id")
+        {
+            var aggregate = Aggregate.function("c[\"id\"] AS userId").groupBy("id");
+            var cond = Condition.filter("id STARTSWITH", "id_find_filter");
+
+            var result = db.aggregate(host, aggregate, cond, "Users").toMap();
+            assertThat(result).hasSize(3);
 
             assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
                 assertThat(id).startsWith("id_find_filter");

--- a/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
@@ -1370,6 +1370,69 @@ class CosmosDatabaseImplTest {
                 assertThat(id).startsWith("id_find_filter");
             });
         }
+
+        // test aggregate(group by "id" without count)
+        {
+            var aggregate = Aggregate.function("id AS userId").groupBy("id");
+            var cond = Condition.filter("id STARTSWITH", "id_find_filter");
+
+            var result = db.aggregate(host, aggregate, cond, "Users").toMap();
+            assertThat(result).hasSize(3);
+
+            // we alias id as userId
+            assertThat(result.get(0).get("id")).isNull();
+
+            assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
+                assertThat(id).startsWith("id_find_filter");
+            });
+        }
+
+    }
+
+    @Test
+    void aggregate_should_work_grouping_by_array() throws Exception {
+
+        var partition = "Users2";
+        var id1 = "grouping_by_array1_" + RandomStringUtils.randomAlphanumeric(3);
+        var id2 = "grouping_by_array2_" + RandomStringUtils.randomAlphanumeric(3);
+        var id3 = "grouping_by_array3_" + RandomStringUtils.randomAlphanumeric(3);
+        var id4 = "grouping_by_array4_" + RandomStringUtils.randomAlphanumeric(3);
+
+        try {
+
+            var data1 = Map.of("id", id1, "orgIds", List.of("org1", "org2"));
+            var data2 = Map.of("id", id2, "orgIds", List.of("org1", "org2"));
+            var data3 = Map.of("id", id3, "orgIds", List.of("org1"));
+            var data4 = Map.of("id", id4, "orgIds", List.of());
+
+
+            db.upsert(host, data1, partition);
+            db.upsert(host, data2, partition);
+            db.upsert(host, data3, partition);
+            db.upsert(host, data4, partition);
+
+            {
+                // test aggregate(min for texts)
+                var aggregate = Aggregate.function("count(1) AS count").groupBy("orgIds");
+
+                // cosmosdb can not sort using aggregate value (like count)
+                var cond = Condition.filter("id STARTSWITH", "grouping_by_array").sort("orgIds", "DESC");
+
+                var result = db.aggregate(host, aggregate, cond, partition).toMap();
+                assertThat(result).hasSize(3);
+
+                assertThat(result).anyMatch(item -> item.get("count").equals(2)
+                        && item.get("orgIds").equals(List.of("org1", "org2")));
+
+            }
+
+
+        } finally {
+            db.delete(host, id1, partition);
+            db.delete(host, id2, partition);
+            db.delete(host, id3, partition);
+        }
+
     }
 
     @Test
@@ -2009,50 +2072,73 @@ class CosmosDatabaseImplTest {
         }
     }
 
-    @Disabled
     /**
      * TODO, This case is not implemented at present for CosmosDB
      */
+    @Disabled
     @Test
     void find_should_work_with_join_using_elem_match() throws Exception {
-        // condition on the same sub array should be both applied to the element(e.g. children.gender = "female" AND children.grade = 5)
-        // If we want to implement this, we can introduce a new SubConditionType like "$ELEM_MATCH" in mongodb
-        { // test returnAllSubArray(true)
-            var cond = new Condition();
-            cond = Condition.filter(SubConditionType.ELEM_MATCH,
-                            Map.of("children.gender", "male",
-                                    "children.grade >=", 5)
-                    )
-                    .sort("lastName", "ASC") //
-                    .limit(10) //
-                    .offset(0)
-                    .join(Set.of("parents", "children"))
-                    .returnAllSubArray(true)
-            ;
-            // test find
-            var result = db.find(coll, cond, "Families").toMap();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-            assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
-        }
-        { // test returnAllSubArray(false)
-            var cond = new Condition();
-            cond = Condition.filter(SubConditionType.ELEM_MATCH,
-                            Map.of("children.gender", "male",
-                                    "children.grade >=", 5)
-                    )
-                    .sort("lastName", "ASC") //
-                    .limit(10) //
-                    .offset(0)
-                    .join(Set.of("parents", "children"))
-                    .returnAllSubArray(false)
-            ;
-            // test find
-            var result = db.find(coll, cond, "Families").toMap();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-            // only sub set of children is returned
-            assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(1);
+
+        var id3 = "Adams";
+        var family3 = Map.of(
+                "id", id3,
+                "children", List.of(
+                        Map.of(
+                                "gender", "male",
+                                "grade", 4
+                        ),
+                        Map.of(
+                                "gender", "female",
+                                "grade", 8
+                        )
+                ));
+
+
+        try {
+            db.upsert(coll, family3, "Families");
+
+            // condition on the same sub array should be both applied to the element(e.g. children.gender = "female" AND children.grade = 5)
+            // If we want to implement this, we can introduce a new SubConditionType like "$ELEM_MATCH" in mongodb
+
+            { // test returnAllSubArray(true)
+                var cond = new Condition();
+                cond = Condition.filter(
+                                "children.gender", "male",
+                                "children.grade >=", 5
+                        )
+                        .sort("lastName", "ASC") //
+                        .limit(10) //
+                        .offset(0)
+                        .join(Set.of("parents", "children"))
+                        .returnAllSubArray(true)
+                ;
+                // test find
+                var result = db.find(coll, cond, "Families").toMap();
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
+            }
+            { // test returnAllSubArray(false)
+                var cond = new Condition();
+                cond = Condition.filter(
+                                "children.gender", "male",
+                                "children.grade >=", 5
+                        )
+                        .sort("lastName", "ASC") //
+                        .limit(10) //
+                        .offset(0)
+                        .join(Set.of("parents", "children"))
+                        .returnAllSubArray(false)
+                ;
+                // test find
+                var result = db.find(coll, cond, "Families").toMap();
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+                // only sub set of children is returned
+                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(1);
+            }
+        }finally {
+            db.delete(coll, id3, "Families");
         }
     }
 

--- a/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplTest.java
@@ -1447,9 +1447,25 @@ class MongoDatabaseImplTest {
             });
         }
 
-        // test aggregate(group by "id" without count)
+        // test aggregate(aggregate using "c.id", group by "id")
         {
-            var aggregate = Aggregate.function("id AS userId").groupBy("id");
+            var aggregate = Aggregate.function("c.id AS userId").groupBy("id");
+            var cond = Condition.filter("id STARTSWITH", "id_find_filter");
+
+            var result = db.aggregate(host, aggregate, cond, "Users").toMap();
+            assertThat(result).hasSize(3);
+
+            // we alias id as userId
+            assertThat(result.get(0).get("id")).isNull();
+
+            assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
+                assertThat(id).startsWith("id_find_filter");
+            });
+        }
+
+        // test aggregate(aggregate using c["id"], group by "id")
+        {
+            var aggregate = Aggregate.function("c[\"id\"] AS userId").groupBy("id");
             var cond = Condition.filter("id STARTSWITH", "id_find_filter");
 
             var result = db.aggregate(host, aggregate, cond, "Users").toMap();

--- a/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplTest.java
@@ -1446,6 +1446,67 @@ class MongoDatabaseImplTest {
                 assertThat(id).startsWith("id_find_filter");
             });
         }
+
+        // test aggregate(group by "id" without count)
+        {
+            var aggregate = Aggregate.function("id AS userId").groupBy("id");
+            var cond = Condition.filter("id STARTSWITH", "id_find_filter");
+
+            var result = db.aggregate(host, aggregate, cond, "Users").toMap();
+            assertThat(result).hasSize(3);
+
+            // we alias id as userId
+            assertThat(result.get(0).get("id")).isNull();
+
+            assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
+                assertThat(id).startsWith("id_find_filter");
+            });
+        }
+
+    }
+
+    @Test
+    void aggregate_should_work_grouping_by_array() throws Exception {
+
+        var partition = "Users2";
+        var id1 = "grouping_by_array1_" + RandomStringUtils.randomAlphanumeric(3);
+        var id2 = "grouping_by_array2_" + RandomStringUtils.randomAlphanumeric(3);
+        var id3 = "grouping_by_array3_" + RandomStringUtils.randomAlphanumeric(3);
+        var id4 = "grouping_by_array4_" + RandomStringUtils.randomAlphanumeric(3);
+
+        try {
+
+            var data1 = Map.of("id", id1, "orgIds", List.of("org1", "org2"));
+            var data2 = Map.of("id", id2, "orgIds", List.of("org1", "org2"));
+            var data3 = Map.of("id", id3, "orgIds", List.of("org1"));
+            var data4 = Map.of("id", id4, "orgIds", List.of());
+
+
+            db.upsert(host, data1, partition);
+            db.upsert(host, data2, partition);
+            db.upsert(host, data3, partition);
+            db.upsert(host, data4, partition);
+
+            {
+                // test aggregate(min for texts)
+                var aggregate = Aggregate.function("count(1) AS count").groupBy("orgIds")
+                        .conditionAfterAggregate(Condition.filter().sort("count", "DESC"));
+                var cond = Condition.filter("id STARTSWITH", "grouping_by_array");
+
+                var result = db.aggregate(host, aggregate, cond, partition).toMap();
+                assertThat(result).hasSize(3);
+
+                assertThat(result.get(0).get("count")).isEqualTo(2);
+                assertThat(result.get(0).get("orgIds")).isEqualTo(List.of("org1", "org2"));
+            }
+
+
+        } finally {
+            db.delete(host, id1, partition);
+            db.delete(host, id2, partition);
+            db.delete(host, id3, partition);
+        }
+
     }
 
     @Test
@@ -2068,44 +2129,65 @@ class MongoDatabaseImplTest {
 
     @Test
     void find_should_work_with_join_using_elem_match() throws Exception {
-        // condition on the same sub array should be both applied to the element(e.g. children.gender = "female" AND children.grade = 5)
-        // If we want to implement this, we can introduce a new SubConditionType like "$ELEM_MATCH" in mongodb
-        { // test returnAllSubArray(true)
-            var cond = new Condition();
-            cond = Condition.filter(SubConditionType.ELEM_MATCH,
-                            Map.of("children.gender", "male",
-                                    "children.grade >=", 5)
-                    )
-                    .sort("lastName", "ASC") //
-                    .limit(10) //
-                    .offset(0)
-                    .join(Set.of("parents", "children"))
-                    .returnAllSubArray(true)
-            ;
-            // test find
-            var result = db.find(host, cond, "Families").toMap();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-            assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
-        }
-        { // test returnAllSubArray(false)
-            var cond = new Condition();
-            cond = Condition.filter(SubConditionType.ELEM_MATCH,
-                            Map.of("children.gender", "male",
-                                    "children.grade >=", 5)
-                    )
-                    .sort("lastName", "ASC") //
-                    .limit(10) //
-                    .offset(0)
-                    .join(Set.of("parents", "children"))
-                    .returnAllSubArray(false)
-            ;
-            // test find
-            var result = db.find(host, cond, "Families").toMap();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-            // only sub set of children is returned
-            assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(1);
+
+        var id3 = "Adams";
+        var family3 = Map.of(
+                "id", id3,
+                "children", List.of(
+                        Map.of(
+                                "gender", "male",
+                                "grade", 4
+                        ),
+                        Map.of(
+                                "gender", "female",
+                                "grade", 8
+                        )
+                ));
+
+
+        try {
+            db.upsert(host, family3, "Families");
+            // condition on the same sub array should be both applied to the element(e.g. children.gender = "female" AND children.grade = 5)
+            // we introduced a new SubConditionType like "$ELEM_MATCH" in mongodb to achieve this
+            { // test returnAllSubArray(true)
+                var cond = new Condition();
+                cond = Condition.filter(SubConditionType.ELEM_MATCH,
+                                Map.of("children.gender", "male",
+                                        "children.grade >=", 5)
+                        )
+                        .sort("lastName", "ASC") //
+                        .limit(10) //
+                        .offset(0)
+                        .join(Set.of("parents", "children"))
+                        .returnAllSubArray(true)
+                ;
+                // test find
+                var result = db.find(host, cond, "Families").toMap();
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
+            }
+            { // test returnAllSubArray(false)
+                var cond = new Condition();
+                cond = Condition.filter(SubConditionType.ELEM_MATCH,
+                                Map.of("children.gender", "male",
+                                        "children.grade >=", 5)
+                        )
+                        .sort("lastName", "ASC") //
+                        .limit(10) //
+                        .offset(0)
+                        .join(Set.of("parents", "children"))
+                        .returnAllSubArray(false)
+                ;
+                // test find
+                var result = db.find(host, cond, "Families").toMap();
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+                // only sub set of children is returned
+                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(1);
+            }
+        }finally {
+            db.delete(host, id3, "Families");
         }
     }
 
@@ -3311,7 +3393,7 @@ class MongoDatabaseImplTest {
 
             var expireAt = mdb.addExpireAt4Mongo(map);
 
-            assertThat(expireAt).isNotNull().isBetween(Instant.now().plusSeconds(thirtyDaysInSeconds), Instant.now().plusSeconds(thirtyDaysInSeconds + 1));
+            assertThat(expireAt).isNotNull().isBetween(Instant.now().plusSeconds(thirtyDaysInSeconds-1), Instant.now().plusSeconds(thirtyDaysInSeconds + 1));
             assertThat(map.get(EXPIRE_AT)).isEqualTo(expireAt);
 
         }

--- a/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImplTest.java
@@ -2563,10 +2563,10 @@ class PostgresDatabaseImplTest {
                         .returnAllSubArray(true)
                 ;
                 // test find
-//                var result = db.find(host, cond, "Families").toMap();
-//                assertThat(result).hasSize(1);
-//                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-//                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
+                var result = db.find(host, cond, "Families").toMap();
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
             }
             { // test returnAllSubArray(false)
                 var cond = new Condition();

--- a/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImplTest.java
@@ -13,6 +13,7 @@ import io.github.thunderz99.cosmos.dto.EvalSkip;
 import io.github.thunderz99.cosmos.dto.FullNameUser;
 import io.github.thunderz99.cosmos.dto.PartialUpdateOption;
 import io.github.thunderz99.cosmos.impl.cosmosdb.CosmosImpl;
+import io.github.thunderz99.cosmos.impl.postgres.dto.QueryContext;
 import io.github.thunderz99.cosmos.impl.postgres.util.TTLUtil;
 import io.github.thunderz99.cosmos.impl.postgres.util.TableUtil;
 import io.github.thunderz99.cosmos.util.EnvUtil;
@@ -1651,7 +1652,7 @@ class PostgresDatabaseImplTest {
 
     @Test
     void aggregate_should_work_grouping_by_id() throws Exception {
-        // test aggregate(simple group by)
+        // test aggregate(group by "id")
         {
             var aggregate = Aggregate.function("COUNT(1) AS facetCount").groupBy("id");
             var cond = Condition.filter("id STARTSWITH", "id_find_filter");
@@ -1666,7 +1667,122 @@ class PostgresDatabaseImplTest {
                     assertThat(id).startsWith("id_find_filter");
             });
         }
+
+        // test aggregate(aggregate using "c.id", group by "id")
+        {
+            var aggregate = Aggregate.function("c.id AS userId").groupBy("id");
+            var cond = Condition.filter("id STARTSWITH", "id_find_filter");
+
+            var result = db.aggregate(host, aggregate, cond, "Users").toMap();
+            assertThat(result).hasSize(3);
+
+            // we alias id as userId
+            assertThat(result.get(0).get("id")).isNull();
+
+            assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
+                assertThat(id).startsWith("id_find_filter");
+            });
+        }
+
+        // test aggregate(aggregate using c["id"], group by "id")
+        {
+            var aggregate = Aggregate.function("c[\"id\"] AS userId").groupBy("id");
+            var cond = Condition.filter("id STARTSWITH", "id_find_filter");
+
+            var result = db.aggregate(host, aggregate, cond, "Users").toMap();
+            assertThat(result).hasSize(3);
+
+            // we alias id as userId
+            assertThat(result.get(0).get("id")).isNull();
+
+            assertThat(result.get(0).get("userId")).isInstanceOfSatisfying(String.class, (id) ->{
+                assertThat(id).startsWith("id_find_filter");
+            });
+        }
     }
+
+    @Test
+    void aggregate_should_work_using_min_for_texts() throws Exception {
+
+        var partition = "Users2";
+        var id1 = "using_min_for_texts1_" + RandomStringUtils.randomAlphanumeric(3);
+        var id2 = "using_min_for_texts2_" + RandomStringUtils.randomAlphanumeric(3);
+        var id3 = "using_min_for_texts3_" + RandomStringUtils.randomAlphanumeric(3);
+
+        try {
+
+            var data1 = Map.of("id", id1, "timeSeries", "2024-01-01");
+            var data2 = Map.of("id", id2, "timeSeries", "2025-01-01");
+            var data3 = Map.of("id", id3, "timeSeries", "2026-04-03");
+
+            db.upsert(host, data1, partition);
+            db.upsert(host, data2, partition);
+            db.upsert(host, data3, partition);
+
+            {
+                // test aggregate(min for texts)
+                var aggregate = Aggregate.function("min(c.timeSeries) AS result");
+                var cond = Condition.filter("id STARTSWITH", "using_min_for_texts");
+
+                var result = db.aggregate(host, aggregate, cond, partition).toMap();
+                assertThat(result).hasSize(1);
+
+                assertThat(result.get(0).get("result")).isEqualTo("2024-01-01");
+            }
+
+
+        } finally {
+            db.delete(host, id1, partition);
+            db.delete(host, id2, partition);
+            db.delete(host, id3, partition);
+        }
+
+    }
+
+    @Test
+    void aggregate_should_work_grouping_by_array() throws Exception {
+
+        var partition = "Users2";
+        var id1 = "grouping_by_array1_" + RandomStringUtils.randomAlphanumeric(3);
+        var id2 = "grouping_by_array2_" + RandomStringUtils.randomAlphanumeric(3);
+        var id3 = "grouping_by_array3_" + RandomStringUtils.randomAlphanumeric(3);
+        var id4 = "grouping_by_array4_" + RandomStringUtils.randomAlphanumeric(3);
+
+        try {
+
+            var data1 = Map.of("id", id1, "orgIds", List.of("org1", "org2"));
+            var data2 = Map.of("id", id2, "orgIds", List.of("org1", "org2"));
+            var data3 = Map.of("id", id3, "orgIds", List.of("org1"));
+            var data4 = Map.of("id", id4, "orgIds", List.of());
+
+
+            db.upsert(host, data1, partition);
+            db.upsert(host, data2, partition);
+            db.upsert(host, data3, partition);
+            db.upsert(host, data4, partition);
+
+            {
+                // test aggregate(min for texts)
+                var aggregate = Aggregate.function("count(1) AS count").groupBy("orgIds")
+                        .conditionAfterAggregate(Condition.filter().sort("count", "DESC"));
+                var cond = Condition.filter("id STARTSWITH", "grouping_by_array");
+
+                var result = db.aggregate(host, aggregate, cond, partition).toMap();
+                assertThat(result).hasSize(3);
+
+                assertThat(result.get(0).get("count")).isEqualTo(2);
+                assertThat(result.get(0).get("orgIds")).isEqualTo(List.of("org1", "org2"));
+            }
+
+
+        } finally {
+            db.delete(host, id1, partition);
+            db.delete(host, id2, partition);
+            db.delete(host, id3, partition);
+        }
+
+    }
+
 
     @Test
     void aggregate_should_work_without_group_by() throws Exception {
@@ -2411,46 +2527,68 @@ class PostgresDatabaseImplTest {
         }
     }
 
-    @Disabled
+    @Test
     void find_should_work_with_join_using_elem_match() throws Exception {
-        // condition on the same sub array should be both applied to the element(e.g. children.gender = "female" AND children.grade = 5)
-        // If we want to implement this, we can introduce a new SubConditionType like "$ELEM_MATCH" in postgres
-        { // test returnAllSubArray(true)
-            var cond = new Condition();
-            cond = Condition.filter(SubConditionType.ELEM_MATCH,
-                            Map.of("children.gender", "male",
-                                    "children.grade >=", 5)
-                    )
-                    .sort("lastName", "ASC") //
-                    .limit(10) //
-                    .offset(0)
-                    .join(Set.of("parents", "children"))
-                    .returnAllSubArray(true)
-            ;
-            // test find
-            var result = db.find(host, cond, "Families").toMap();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-            assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
-        }
-        { // test returnAllSubArray(false)
-            var cond = new Condition();
-            cond = Condition.filter(SubConditionType.ELEM_MATCH,
-                            Map.of("children.gender", "male",
-                                    "children.grade >=", 5)
-                    )
-                    .sort("lastName", "ASC") //
-                    .limit(10) //
-                    .offset(0)
-                    .join(Set.of("parents", "children"))
-                    .returnAllSubArray(false)
-            ;
-            // test find
-            var result = db.find(host, cond, "Families").toMap();
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
-            // only sub set of children is returned
-            assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(1);
+
+        var id3 = "Adams";
+        var family3 = Map.of(
+                "id", id3,
+                "children", List.of(
+                        Map.of(
+                                "gender", "male",
+                                "grade", 4
+                        ),
+                        Map.of(
+                                "gender", "female",
+                                "grade", 8
+                        )
+                ));
+
+
+        try {
+            db.upsert(host, family3, "Families");
+
+            // condition on the same sub array should be both applied to the element(e.g. children.gender = "female" AND children.grade = 5)
+            // we introduced a new SubConditionType like "$ELEM_MATCH" in postgres to achieve this
+            { // test returnAllSubArray(true)
+                var cond = new Condition();
+                cond = Condition.filter(SubConditionType.ELEM_MATCH,
+                                Map.of("children.gender", "male",
+                                        "children.grade >=", 5)
+                        )
+                        .sort("lastName", "ASC") //
+                        .limit(10) //
+                        .offset(0)
+                        .join(Set.of("parents", "children"))
+                        .returnAllSubArray(true)
+                ;
+                // test find
+//                var result = db.find(host, cond, "Families").toMap();
+//                assertThat(result).hasSize(1);
+//                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+//                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(3);
+            }
+            { // test returnAllSubArray(false)
+                var cond = new Condition();
+                cond = Condition.filter(SubConditionType.ELEM_MATCH,
+                                Map.of("children.gender", "male",
+                                        "children.grade >=", 5)
+                        )
+                        .sort("lastName", "ASC") //
+                        .limit(10) //
+                        .offset(0)
+                        .join(Set.of("parents", "children"))
+                        .returnAllSubArray(false)
+                ;
+                // test find
+                var result = db.find(host, cond, "Families").toMap();
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getOrDefault("id", "")).isEqualTo("WakefieldFamily");
+                // only sub set of children is returned
+                assertThat((List<Map<String, Object>>) result.get(0).get("children")).hasSize(1);
+            }
+        }finally {
+            db.delete(host, id3, "Families");
         }
     }
 

--- a/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresImplTest.java
@@ -1,6 +1,7 @@
 package io.github.thunderz99.cosmos.impl.postgres;
 
 import io.github.thunderz99.cosmos.impl.mongo.MongoImpl;
+import io.github.thunderz99.cosmos.impl.postgres.dto.QueryContext;
 import io.github.thunderz99.cosmos.util.EnvUtil;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
@@ -105,6 +106,17 @@ public class PostgresImplTest {
             var db2 = (PostgresDatabaseImpl)cosmos.getDatabase(db);
             assertThat(db2.getAccount()).isNotEmpty();
             assertThat(db2.getDatabaseName()).isEqualTo(db);
+
+            {
+                //QueryContext toJson should work
+                var queryContext = QueryContext.create().databaseImpl(db2);
+                queryContext.schemaName = coll;
+                queryContext.tableName = "Users";
+
+                var json = queryContext.toString();
+                assertThat(json).isNotNull().contains(queryContext.schemaName, queryContext.tableName)
+                        .doesNotContain("databaseImpl");
+            }
 
         } finally {
             if(cosmos != null) {

--- a/src/test/java/io/github/thunderz99/cosmos/impl/postgres/util/PGAggregateUtilTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/postgres/util/PGAggregateUtilTest.java
@@ -54,4 +54,36 @@ class PGAggregateUtilTest {
         assertThat(resultMaps.get(2).get("itemsCount")).isInstanceOf(Integer.class).isEqualTo(100);
         assertThat(resultMaps.get(2).get("itemsWithinRange")).isInstanceOf(Integer.class).isEqualTo(Integer.MAX_VALUE); // Should remain Integer
     }
+
+    @Test
+    void convertJsonb() {
+        // Setup
+
+        // Test data setup
+        List<Map<String, Object>> testMaps = new ArrayList<>();
+        LinkedHashMap<String, Object> map1 = new LinkedHashMap<>();
+        map1.put("itemsCount", 1L);
+        map1.put("name", "TestName1");
+        LinkedHashMap<String, Object> map2 = new LinkedHashMap<>();
+        map2.put("itemsCount", Long.MAX_VALUE);
+        map2.put("name", "TestName2");
+        LinkedHashMap<String, Object> map3 = new LinkedHashMap<>();
+        map3.put("itemsCount", 100L);
+        map3.put("itemsWithinRange", Integer.MAX_VALUE);
+        testMaps.add(map1);
+        testMaps.add(map2);
+        testMaps.add(map3);
+
+        // Call the method under test
+        var resultMaps = PGAggregateUtil.convertAggregateResultsToInteger(testMaps);
+
+        // Assertions
+        assertThat(resultMaps).isNotNull();
+        assertThat(resultMaps.size()).isEqualTo(3);
+
+        assertThat(resultMaps.get(0).get("itemsCount")).isInstanceOf(Integer.class).isEqualTo(1);
+        assertThat(resultMaps.get(1).get("itemsCount")).isInstanceOf(Long.class).isEqualTo(Long.MAX_VALUE); // Should remain Long because it's out of Integer range
+        assertThat(resultMaps.get(2).get("itemsCount")).isInstanceOf(Integer.class).isEqualTo(100);
+        assertThat(resultMaps.get(2).get("itemsWithinRange")).isInstanceOf(Integer.class).isEqualTo(Integer.MAX_VALUE); // Should remain Integer
+    }
 }

--- a/src/test/java/io/github/thunderz99/cosmos/util/NumberUtilTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/util/NumberUtilTest.java
@@ -2,6 +2,8 @@ package io.github.thunderz99.cosmos.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NumberUtilTest {
@@ -14,12 +16,17 @@ class NumberUtilTest {
         assertThat(NumberUtil.convertNumberToIntIfCompatible(456)).isEqualTo(456); // Already Integer
         assertThat(NumberUtil.convertNumberToIntIfCompatible(789.0)).isEqualTo(789); // Double with no fractional part
         assertThat(NumberUtil.convertNumberToIntIfCompatible(101.0f)).isEqualTo(101); // Float with no fractional part
+        assertThat(NumberUtil.convertNumberToIntIfCompatible(new BigDecimal("101.0"))).isEqualTo(101); // BigDecimal with no fractional part
+        assertThat(NumberUtil.convertNumberToIntIfCompatible(new BigDecimal("30"))).isEqualTo(30); // BigDecimal with no fractional part
+
 
         // Test cases where original number should be returned
         assertThat(NumberUtil.convertNumberToIntIfCompatible(Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE); // Long out of Integer range
         assertThat(NumberUtil.convertNumberToIntIfCompatible(123.45)).isEqualTo(123.45); // Double with fractional part
         assertThat(NumberUtil.convertNumberToIntIfCompatible(678.9f)).isEqualTo(678.9f); // Float with fractional part
         assertThat(NumberUtil.convertNumberToIntIfCompatible(Integer.MAX_VALUE + 1L)).isEqualTo(Integer.MAX_VALUE + 1L); // Long exactly one more than Integer.MAX_VALUE
+        assertThat(NumberUtil.convertNumberToIntIfCompatible(new BigDecimal("35.6494"))).isEqualTo(new BigDecimal("35.6494")); // BigDecimal with fractional part
+
 
         // Edge cases
         assertThat(NumberUtil.convertNumberToIntIfCompatible((double) Integer.MIN_VALUE)).isEqualTo(Integer.MIN_VALUE); // Double at the edge of Integer range


### PR DESCRIPTION


* for postgres 

  * support GROUP BY an array field.

    * e.g. `Aggregate.function("COUNT(*) as count").groupBy("orgIds")`
    * where `orgIds` maybe `["id1", "id2"]`.
    * this is already supported in cosmos and mongo. add support for postgres

  * support ELEM_MATCH when using join query

    * e.g. 

    * ```
      Condition.filter(SubCondType.ELEM_MATCH, Map.of(
                        "children.gender", "male",
                        "children.grade >=", 5
                       ))
                       .join(Set.of("children"))
      ```

    * this find the single child who's gender is "male" and grade >= 5

    * this is now supported by mongo and postgres. maybe in the future, also supported by cosmos

  * support min aggregate for text field.

    * e.g.  `Aggregate.function("min(c.timeSeries) AS result");`
    * where timeSeries is string like "2024-01-01"
    * this is already supported in cosmos and mongo. add support for postgres

