### PR TITLE
feat: add bulkPatch support for CosmosDB/PostgreSQL/Mongo with per-item result classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,33 @@ The main difference between Partial update and Patch is that:
 * Partial update is focused at insert/replace fields' values. And is able to support updating 10 more fields in one call.
 * Patch is focused to implementing a method similar to JSON Patch, which supports more complicated ops like "Add, Set, Replace, Remove, Increment". And is not able to support ops exceeding 10 in one patch call.
 
+### Bulk Patch
+
+Bulk patch is a non-transactional bulk operation for patch updates.
+
+```java
+// 1) Apply the same patch operations to multiple ids
+var ids = List.of("id001", "id002", "id003");
+var operations = PatchOperations.create()
+        .set("/status", "ENABLED")
+        .increment("/version", 1);
+
+var result1 = db.bulkPatch("Collection1", ids, operations, "Users");
+
+// 2) Apply different patch operations per id
+var patchList = List.of(
+        BulkPatchOperation.of("id001", PatchOperations.create().set("/status", "ENABLED")),
+        BulkPatchOperation.of("id002", PatchOperations.create().set("/status", "DISABLED"))
+);
+
+var result2 = db.bulkPatch("Collection1", patchList, "Users");
+```
+
+Return value is `CosmosBulkResult`:
+
+* `successList`: patched documents (or document ids depending on implementation)
+* `fatalList`: failed items with `CosmosException` (for example, target id not found)
+
 ### Complex queries
 
 ```java

--- a/src/main/java/io/github/thunderz99/cosmos/dto/BulkPatchOperation.java
+++ b/src/main/java/io/github/thunderz99/cosmos/dto/BulkPatchOperation.java
@@ -1,0 +1,47 @@
+package io.github.thunderz99.cosmos.dto;
+
+import io.github.thunderz99.cosmos.v4.PatchOperations;
+
+/**
+ * A patch task used by bulkPatch.
+ */
+public class BulkPatchOperation {
+
+    /**
+     * Target document id.
+     */
+    public String id;
+
+    /**
+     * Patch operations for the target document.
+     */
+    public PatchOperations operations;
+
+    /**
+     * Create an empty operation.
+     */
+    public BulkPatchOperation() {
+    }
+
+    /**
+     * Create an operation with id and patch operations.
+     *
+     * @param id         target document id
+     * @param operations patch operations
+     */
+    public BulkPatchOperation(String id, PatchOperations operations) {
+        this.id = id;
+        this.operations = operations;
+    }
+
+    /**
+     * Build a bulk patch operation.
+     *
+     * @param id         target document id
+     * @param operations patch operations
+     * @return BulkPatchOperation
+     */
+    public static BulkPatchOperation of(String id, PatchOperations operations) {
+        return new BulkPatchOperation(id, operations);
+    }
+}

--- a/src/main/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImpl.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImpl.java
@@ -1554,6 +1554,9 @@ public class MongoDatabaseImpl implements CosmosDatabase {
             var chunkIds = ids.subList(from, to);
             int matchedCount = 0;
 
+            // Intentionally use per-id updateOne here instead of bulkWrite:
+            // we need deterministic success/failure classification for each id (including not-found ids),
+            // while bulkWrite only exposes aggregated counters and does not map unmatched items by id.
             for (var id : chunkIds) {
                 try {
                     var updateResult = container.updateOne(Filters.eq("_id", id), update);
@@ -1598,6 +1601,9 @@ public class MongoDatabaseImpl implements CosmosDatabase {
             var chunkData = data.subList(from, to);
             int matchedCount = 0;
 
+            // Intentionally use per-id updateOne here instead of bulkWrite:
+            // we need deterministic success/failure classification for each id (including not-found ids),
+            // while bulkWrite only exposes aggregated counters and does not map unmatched items by id.
             for (var operation : chunkData) {
                 try {
                     // Keep per-item operation immutable by copying before adding timestamp.

--- a/src/main/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImpl.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImpl.java
@@ -14,6 +14,7 @@ import com.mongodb.client.model.*;
 import io.github.thunderz99.cosmos.*;
 import io.github.thunderz99.cosmos.condition.Aggregate;
 import io.github.thunderz99.cosmos.condition.Condition;
+import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
 import io.github.thunderz99.cosmos.dto.CosmosBulkResult;
 import io.github.thunderz99.cosmos.dto.CosmosSqlQuerySpec;
 import io.github.thunderz99.cosmos.dto.FilterOptions;
@@ -43,7 +44,8 @@ public class MongoDatabaseImpl implements CosmosDatabase {
 
     private static Logger log = LoggerFactory.getLogger(MongoDatabaseImpl.class);
 
-    static final int MAX_BATCH_NUMBER_OF_OPERATION = 100;
+    static final int MAX_BATCH_NUMBER_OF_OPERATION = CosmosLimits.BATCH_OPERATION_LIMIT;
+    static final int BULK_PATCH_CHUNK_SIZE = CosmosLimits.BULK_CHUNK_SIZE;
 
     /**
      * field automatically added to contain the expiration timestamp
@@ -1308,6 +1310,33 @@ public class MongoDatabaseImpl implements CosmosDatabase {
         Checker.checkNotEmpty(data, "create data " + coll + " " + partition);
     }
 
+    static void doCheckBeforeBulkPatch(String coll, List<String> ids, PatchOperations operations, String partition) {
+        Checker.checkNotBlank(coll, "coll");
+        Checker.checkNotBlank(partition, "partition");
+        Checker.checkNotEmpty(ids, "bulkPatch ids " + coll + " " + partition);
+        Checker.checkNotNull(operations, "bulkPatch operations");
+        Preconditions.checkArgument(operations.size() <= PatchOperations.LIMIT,
+                "Size of operations should be less or equal to 10. We got: %d, which exceed the limit 10",
+                operations.size());
+        checkValidId(ids);
+    }
+
+    static void doCheckBeforeBulkPatch(String coll, List<BulkPatchOperation> data, String partition) {
+        Checker.checkNotBlank(coll, "coll");
+        Checker.checkNotBlank(partition, "partition");
+        Checker.checkNotEmpty(data, "bulkPatch data " + coll + " " + partition);
+
+        for (var operation : data) {
+            Checker.checkNotNull(operation, "bulkPatch operation");
+            Checker.checkNotBlank(operation.id, "bulkPatch operation id");
+            checkValidId(operation.id);
+            Checker.checkNotNull(operation.operations, "bulkPatch operation patch operations");
+            Preconditions.checkArgument(operation.operations.size() <= PatchOperations.LIMIT,
+                    "Size of operations should be less or equal to 10. We got: %d, which exceed the limit 10",
+                    operation.operations.size());
+        }
+    }
+
     /**
      * Bulk create documents.
      * Note: Non-transaction. Have no number limit in theoretically.
@@ -1498,6 +1527,105 @@ public class MongoDatabaseImpl implements CosmosDatabase {
         return ret;
     }
 
+    /**
+     * Bulk patch documents with the same patch operations.
+     *
+     * @param coll       collection name
+     * @param ids        target document ids
+     * @param operations patch operations
+     * @param partition  partition name
+     * @return CosmosBulkResult
+     * @throws Exception cosmos exception
+     */
+    public CosmosBulkResult bulkPatch(String coll, List<String> ids, PatchOperations operations, String partition) throws Exception {
+        doCheckBeforeBulkPatch(coll, ids, operations, partition);
+
+        // Keep the same timestamp for this bulk execution to avoid per-item mutation.
+        var operationsWithTs = operations.copy().set("/_ts", TimestampUtil.getTimestampInDouble());
+        var patchData = JsonPatchUtil.toMongoPatchData(operationsWithTs);
+
+        var container = this.client.getDatabase(coll).getCollection(partition);
+        var update = Updates.combine(patchData);
+        var totalModifiedCount = 0L;
+        var ret = new CosmosBulkResult();
+
+        for (int from = 0; from < ids.size(); from += BULK_PATCH_CHUNK_SIZE) {
+            var to = Math.min(from + BULK_PATCH_CHUNK_SIZE, ids.size());
+            var chunkIds = ids.subList(from, to);
+            int matchedCount = 0;
+
+            for (var id : chunkIds) {
+                try {
+                    var updateResult = container.updateOne(Filters.eq("_id", id), update);
+                    if (updateResult.getMatchedCount() > 0) {
+                        ret.successList.add(new CosmosDocument(Map.of("id", id)));
+                        matchedCount++;
+                    } else {
+                        ret.fatalList.add(new CosmosException(500, id, "Failed to patch"));
+                    }
+                } catch (Exception e) {
+                    ret.fatalList.add(new CosmosException(500, id, "Failed to patch", e));
+                }
+            }
+
+            totalModifiedCount += matchedCount;
+        }
+
+        log.info("Bulk patched(same operations) Documents in collection:{}, partition:{}, modifiedCount:{}, account:{}",
+                coll, partition, totalModifiedCount, getAccount());
+
+        return ret;
+    }
+
+    /**
+     * Bulk patch documents with different patch operations.
+     *
+     * @param coll      collection name
+     * @param data      bulk patch operations
+     * @param partition partition name
+     * @return CosmosBulkResult
+     * @throws Exception cosmos exception
+     */
+    public CosmosBulkResult bulkPatch(String coll, List<BulkPatchOperation> data, String partition) throws Exception {
+        doCheckBeforeBulkPatch(coll, data, partition);
+
+        var container = this.client.getDatabase(coll).getCollection(partition);
+        var totalModifiedCount = 0L;
+        var ret = new CosmosBulkResult();
+
+        for (int from = 0; from < data.size(); from += BULK_PATCH_CHUNK_SIZE) {
+            var to = Math.min(from + BULK_PATCH_CHUNK_SIZE, data.size());
+            var chunkData = data.subList(from, to);
+            int matchedCount = 0;
+
+            for (var operation : chunkData) {
+                try {
+                    // Keep per-item operation immutable by copying before adding timestamp.
+                    var operationsWithTs = operation.operations.copy().set("/_ts", TimestampUtil.getTimestampInDouble());
+                    var patchData = JsonPatchUtil.toMongoPatchData(operationsWithTs);
+                    var update = Updates.combine(patchData);
+
+                    var updateResult = container.updateOne(Filters.eq("_id", operation.id), update);
+                    if (updateResult.getMatchedCount() > 0) {
+                        ret.successList.add(new CosmosDocument(Map.of("id", operation.id)));
+                        matchedCount++;
+                    } else {
+                        ret.fatalList.add(new CosmosException(500, operation.id, "Failed to patch"));
+                    }
+                } catch (Exception e) {
+                    ret.fatalList.add(new CosmosException(500, operation.id, "Failed to patch", e));
+                }
+            }
+
+            totalModifiedCount += matchedCount;
+        }
+
+        log.info("Bulk patched Documents in collection:{}, partition:{}, modifiedCount:{}, account:{}",
+                coll, partition, totalModifiedCount, getAccount());
+
+        return ret;
+    }
+
     @Override
     public boolean ping(String coll) throws Exception {
         var docs = this.find(coll, Condition.filter().limit(1), "_ping");
@@ -1508,7 +1636,7 @@ public class MongoDatabaseImpl implements CosmosDatabase {
         // There's a current limit of 100 operations per TransactionalBatch to ensure the performance is as expected and within SLAs:
         // https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/transactional-batch?tabs=dotnet#limitations
         if (data.size() > MAX_BATCH_NUMBER_OF_OPERATION) {
-            throw new IllegalArgumentException("The number of data operations should not exceed 100.");
+            throw new IllegalArgumentException("The number of data operations should not exceed %d.".formatted(MAX_BATCH_NUMBER_OF_OPERATION));
         }
     }
 

--- a/src/main/java/io/github/thunderz99/cosmos/util/CosmosLimits.java
+++ b/src/main/java/io/github/thunderz99/cosmos/util/CosmosLimits.java
@@ -1,0 +1,20 @@
+package io.github.thunderz99.cosmos.util;
+
+/**
+ * Shared limits for batch/chunk style operations.
+ */
+public final class CosmosLimits {
+
+    private CosmosLimits() {
+    }
+
+    /**
+     * Maximum operations allowed in one batch request.
+     */
+    public static final int BATCH_OPERATION_LIMIT = 100;
+
+    /**
+     * Default chunk size used by bulk operations.
+     */
+    public static final int BULK_CHUNK_SIZE = BATCH_OPERATION_LIMIT;
+}

--- a/src/main/java/io/github/thunderz99/cosmos/v4/PatchOperations.java
+++ b/src/main/java/io/github/thunderz99/cosmos/v4/PatchOperations.java
@@ -175,4 +175,39 @@ public class PatchOperations {
     public List<PatchOperation> getPatchOperations() {
         return this.operations;
     }
+
+    /**
+     * Create a deep copy of current patch operations.
+     *
+     * @return copied PatchOperations
+     */
+    public PatchOperations copy() {
+        var copied = PatchOperations.create();
+        for (var _operation : this.operations) {
+            var operation = (PatchOperationCore<?>) _operation;
+            var op = operation.getOperationType();
+            var path = operation.getPath();
+            var value = operation.getResource();
+
+            switch (op) {
+                case ADD -> copied.add(path, value);
+                case REMOVE -> copied.remove(path);
+                case REPLACE -> copied.replace(path, value);
+                case SET -> copied.set(path, value);
+                case INCREMENT -> {
+                    if (value instanceof Double v) {
+                        copied.increment(path, v);
+                    } else if (value instanceof Float v) {
+                        copied.increment(path, v.doubleValue());
+                    } else if (value instanceof Number v) {
+                        copied.increment(path, v.longValue());
+                    } else {
+                        throw new IllegalArgumentException("Unsupported increment value type: " + value);
+                    }
+                }
+                default -> throw new UnsupportedOperationException("Unsupported JSON Patch operation: " + op);
+            }
+        }
+        return copied;
+    }
 }

--- a/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplBulkPatchTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplBulkPatchTest.java
@@ -1,0 +1,162 @@
+package io.github.thunderz99.cosmos.impl.cosmosdb;
+
+import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
+import io.github.thunderz99.cosmos.v4.PatchOperations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CosmosDatabaseImplBulkPatchTest {
+
+    @Test
+    void doCheckBeforeBulkPatch_should_work() {
+        var operation = BulkPatchOperation.of("bulk_patch_id_001", PatchOperations.create().set("/name", "Alice"));
+
+        assertThatCode(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_work_for_boundary_max_operations() {
+        var patchOperations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10);
+
+        var operation = BulkPatchOperation.of("bulk_patch_id_002", patchOperations);
+
+        assertThatCode(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_coll_is_blank() {
+        var operation = BulkPatchOperation.of("bulk_patch_id_003", PatchOperations.create().set("/name", "Bob"));
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("", List.of(operation), "Users"))
+                .hasMessageContaining("coll should be non-blank");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_partition_is_blank() {
+        var operation = BulkPatchOperation.of("bulk_patch_id_004", PatchOperations.create().set("/name", "Bob"));
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), ""))
+                .hasMessageContaining("partition should be non-blank");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_data_is_empty_or_null() {
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(), "Users"))
+                .hasMessageContaining("should not be empty collection");
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", null, "Users"))
+                .hasMessageContaining("should not be empty collection");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_operation_is_null() {
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", Arrays.asList((BulkPatchOperation) null), "Users"))
+                .hasMessageContaining("bulkPatch operation should not be null");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_id_is_blank() {
+        var operation = BulkPatchOperation.of("", PatchOperations.create().set("/name", "Carl"));
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("bulkPatch operation id should be non-blank");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_id_is_invalid() {
+        var operation = BulkPatchOperation.of("invalid_id\n", PatchOperations.create().set("/name", "Dave"));
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("id cannot contain \\t or \\n or \\r or /");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_patch_operations_is_null() {
+        var operation = BulkPatchOperation.of("bulk_patch_id_005", null);
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("bulkPatch operation patch operations should not be null");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_patch_operations_exceed_limit() {
+        var patchOperations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10)
+                .set("/k11", 11);
+
+        var operation = BulkPatchOperation.of("bulk_patch_id_006", patchOperations);
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("Size of operations should be less or equal to 10");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_work() {
+        var ids = List.of("bulk_patch_id_101", "bulk_patch_id_102");
+        var operations = PatchOperations.create().set("/name", "Eve");
+
+        assertThatCode(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, operations, "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_throw_when_ids_empty() {
+        var operations = PatchOperations.create().set("/name", "Eve");
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(), operations, "Users"))
+                .hasMessageContaining("should not be empty collection");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_throw_when_operations_null() {
+        var ids = List.of("bulk_patch_id_103");
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, null, "Users"))
+                .hasMessageContaining("bulkPatch operations should not be null");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_throw_when_operations_exceed_limit() {
+        var ids = List.of("bulk_patch_id_104");
+        var operations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10)
+                .set("/k11", 11);
+
+        assertThatThrownBy(() -> CosmosDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, operations, "Users"))
+                .hasMessageContaining("Size of operations should be less or equal to 10");
+    }
+}

--- a/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/cosmosdb/CosmosDatabaseImplTest.java
@@ -18,6 +18,7 @@ import io.github.thunderz99.cosmos.*;
 import io.github.thunderz99.cosmos.condition.Aggregate;
 import io.github.thunderz99.cosmos.condition.Condition;
 import io.github.thunderz99.cosmos.condition.SubConditionType;
+import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
 import io.github.thunderz99.cosmos.dto.CheckBox;
 import io.github.thunderz99.cosmos.dto.EvalSkip;
 import io.github.thunderz99.cosmos.dto.FullNameUser;
@@ -3522,6 +3523,69 @@ class CosmosDatabaseImplTest {
             db.delete(coll, id, partition);
         }
 
+    }
+
+    @Test
+    void bulkPatch_should_classify_missing_ids_correctly_with_same_operations() throws Exception {
+        var partition = "PatchTests";
+        var existingId = "bulkPatch_existing_id_cosmos";
+        var missingId = "bulkPatch_missing_id_cosmos";
+        var data = Map.of(
+                "id", existingId,
+                "status", "NEW"
+        );
+        var ids = List.of(missingId, existingId);
+
+        try {
+            db.create(coll, data, partition);
+
+            var operations = PatchOperations.create().set("/status", "DONE");
+            var result = db.bulkPatch(coll, ids, operations, partition);
+
+            assertThat(result.successList)
+                    .extracting(it -> it.toMap().get("id"))
+                    .contains(existingId);
+            assertThat(result.fatalList)
+                    .extracting(CosmosException::getStatusCode)
+                    .contains(404);
+
+            var item = db.read(coll, existingId, partition).toMap();
+            assertThat(item.get("status")).isEqualTo("DONE");
+        } finally {
+            db.delete(coll, existingId, partition);
+        }
+    }
+
+    @Test
+    void bulkPatch_should_classify_missing_ids_correctly_with_per_item_operations() throws Exception {
+        var partition = "PatchTests";
+        var existingId = "bulkPatch_per_item_existing_id_cosmos";
+        var missingId = "bulkPatch_per_item_missing_id_cosmos";
+        var data = Map.of(
+                "id", existingId,
+                "status", "NEW"
+        );
+        var patchList = List.of(
+                new BulkPatchOperation(missingId, PatchOperations.create().set("/status", "DONE")),
+                new BulkPatchOperation(existingId, PatchOperations.create().set("/status", "UPDATED"))
+        );
+
+        try {
+            db.create(coll, data, partition);
+
+            var result = db.bulkPatch(coll, patchList, partition);
+            assertThat(result.successList)
+                    .extracting(it -> it.toMap().get("id"))
+                    .contains(existingId);
+            assertThat(result.fatalList)
+                    .extracting(CosmosException::getStatusCode)
+                    .contains(404);
+
+            var item = db.read(coll, existingId, partition).toMap();
+            assertThat(item.get("status")).isEqualTo("UPDATED");
+        } finally {
+            db.delete(coll, existingId, partition);
+        }
     }
 
     @Test

--- a/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplBulkPatchTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplBulkPatchTest.java
@@ -1,0 +1,102 @@
+package io.github.thunderz99.cosmos.impl.mongo;
+
+import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
+import io.github.thunderz99.cosmos.v4.PatchOperations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MongoDatabaseImplBulkPatchTest {
+
+    @Test
+    void doCheckBeforeBulkPatch_should_work() {
+        var operation = BulkPatchOperation.of("bulk_patch_id_001", PatchOperations.create().set("/name", "Alice"));
+
+        assertThatCode(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_work_for_boundary_max_operations() {
+        var patchOperations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10);
+
+        var operation = BulkPatchOperation.of("bulk_patch_id_002", patchOperations);
+
+        assertThatCode(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_data_is_empty_or_null() {
+        assertThatThrownBy(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(), "Users"))
+                .hasMessageContaining("should not be empty collection");
+        assertThatThrownBy(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", null, "Users"))
+                .hasMessageContaining("should not be empty collection");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_operation_is_null() {
+        assertThatThrownBy(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", Arrays.asList((BulkPatchOperation) null), "Users"))
+                .hasMessageContaining("bulkPatch operation should not be null");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_id_is_invalid() {
+        var operation = BulkPatchOperation.of("invalid_id\n", PatchOperations.create().set("/name", "Dave"));
+
+        assertThatThrownBy(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("id cannot contain \\t or \\n or \\r or /");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_patch_operations_exceed_limit() {
+        var patchOperations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10)
+                .set("/k11", 11);
+
+        var operation = BulkPatchOperation.of("bulk_patch_id_006", patchOperations);
+
+        assertThatThrownBy(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("Size of operations should be less or equal to 10");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_work() {
+        var ids = List.of("bulk_patch_id_101", "bulk_patch_id_102");
+        var operations = PatchOperations.create().set("/name", "Eve");
+
+        assertThatCode(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, operations, "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_throw_when_operations_null() {
+        var ids = List.of("bulk_patch_id_103");
+
+        assertThatThrownBy(() -> MongoDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, null, "Users"))
+                .hasMessageContaining("bulkPatch operations should not be null");
+    }
+}

--- a/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/mongo/MongoDatabaseImplTest.java
@@ -18,6 +18,7 @@ import io.github.thunderz99.cosmos.*;
 import io.github.thunderz99.cosmos.condition.Aggregate;
 import io.github.thunderz99.cosmos.condition.Condition;
 import io.github.thunderz99.cosmos.condition.SubConditionType;
+import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
 import io.github.thunderz99.cosmos.dto.CheckBox;
 import io.github.thunderz99.cosmos.dto.EvalSkip;
 import io.github.thunderz99.cosmos.dto.FullNameUser;
@@ -3602,6 +3603,69 @@ class MongoDatabaseImplTest {
 
         } finally {
             db.batchDelete(host, userList, partition);
+        }
+    }
+
+    @Test
+    void bulkPatch_should_classify_missing_ids_correctly_with_same_operations() throws Exception {
+        var partition = "Users";
+        var existingId = "bulkPatch_existing_id";
+        var missingId = "bulkPatch_missing_id";
+        var data = Map.of(
+                "id", existingId,
+                "status", "NEW"
+        );
+        var ids = List.of(missingId, existingId);
+
+        try {
+            db.create(host, data, partition);
+
+            var operations = PatchOperations.create().set("/status", "DONE");
+            var result = db.bulkPatch(host, ids, operations, partition);
+
+            assertThat(result.successList)
+                    .extracting(it -> it.toMap().get("id"))
+                    .containsExactly(existingId);
+            assertThat(result.fatalList)
+                    .extracting(CosmosException::getCode)
+                    .containsExactly(missingId);
+
+            var item = db.read(host, existingId, partition).toMap();
+            assertThat(item.get("status")).isEqualTo("DONE");
+        } finally {
+            db.delete(host, existingId, partition);
+        }
+    }
+
+    @Test
+    void bulkPatch_should_classify_missing_ids_correctly_with_per_item_operations() throws Exception {
+        var partition = "Users";
+        var existingId = "bulkPatch_per_item_existing_id";
+        var missingId = "bulkPatch_per_item_missing_id";
+        var data = Map.of(
+                "id", existingId,
+                "status", "NEW"
+        );
+        var patchList = List.of(
+                new BulkPatchOperation(missingId, PatchOperations.create().set("/status", "DONE")),
+                new BulkPatchOperation(existingId, PatchOperations.create().set("/status", "UPDATED"))
+        );
+
+        try {
+            db.create(host, data, partition);
+
+            var result = db.bulkPatch(host, patchList, partition);
+            assertThat(result.successList)
+                    .extracting(it -> it.toMap().get("id"))
+                    .containsExactly(existingId);
+            assertThat(result.fatalList)
+                    .extracting(CosmosException::getCode)
+                    .containsExactly(missingId);
+
+            var item = db.read(host, existingId, partition).toMap();
+            assertThat(item.get("status")).isEqualTo("UPDATED");
+        } finally {
+            db.delete(host, existingId, partition);
         }
     }
 

--- a/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImplBulkPatchTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImplBulkPatchTest.java
@@ -1,0 +1,102 @@
+package io.github.thunderz99.cosmos.impl.postgres;
+
+import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
+import io.github.thunderz99.cosmos.v4.PatchOperations;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PostgresDatabaseImplBulkPatchTest {
+
+    @Test
+    void doCheckBeforeBulkPatch_should_work() {
+        var operation = BulkPatchOperation.of("bulk_patch_id_001", PatchOperations.create().set("/name", "Alice"));
+
+        assertThatCode(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_work_for_boundary_max_operations() {
+        var patchOperations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10);
+
+        var operation = BulkPatchOperation.of("bulk_patch_id_002", patchOperations);
+
+        assertThatCode(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_data_is_empty_or_null() {
+        assertThatThrownBy(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(), "Users"))
+                .hasMessageContaining("should not be empty collection");
+        assertThatThrownBy(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", null, "Users"))
+                .hasMessageContaining("should not be empty collection");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_operation_is_null() {
+        assertThatThrownBy(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", Arrays.asList((BulkPatchOperation) null), "Users"))
+                .hasMessageContaining("bulkPatch operation should not be null");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_id_is_invalid() {
+        var operation = BulkPatchOperation.of("invalid_id\n", PatchOperations.create().set("/name", "Dave"));
+
+        assertThatThrownBy(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("id cannot contain \\t or \\n or \\r or /");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_should_throw_when_patch_operations_exceed_limit() {
+        var patchOperations = PatchOperations.create()
+                .set("/k1", 1)
+                .set("/k2", 2)
+                .set("/k3", 3)
+                .set("/k4", 4)
+                .set("/k5", 5)
+                .set("/k6", 6)
+                .set("/k7", 7)
+                .set("/k8", 8)
+                .set("/k9", 9)
+                .set("/k10", 10)
+                .set("/k11", 11);
+
+        var operation = BulkPatchOperation.of("bulk_patch_id_006", patchOperations);
+
+        assertThatThrownBy(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", List.of(operation), "Users"))
+                .hasMessageContaining("Size of operations should be less or equal to 10");
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_work() {
+        var ids = List.of("bulk_patch_id_101", "bulk_patch_id_102");
+        var operations = PatchOperations.create().set("/name", "Eve");
+
+        assertThatCode(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, operations, "Users"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void doCheckBeforeBulkPatch_with_ids_should_throw_when_operations_null() {
+        var ids = List.of("bulk_patch_id_103");
+
+        assertThatThrownBy(() -> PostgresDatabaseImpl.doCheckBeforeBulkPatch("Users", ids, null, "Users"))
+                .hasMessageContaining("bulkPatch operations should not be null");
+    }
+}

--- a/src/test/java/io/github/thunderz99/cosmos/v4/PatchOperationsTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/v4/PatchOperationsTest.java
@@ -47,4 +47,30 @@ class PatchOperationsTest {
 
     }
 
+    @Test
+    void copy_should_work() {
+        var operations = PatchOperations.create()
+                .add("/obj", new DummyPojo("Alice", 20))
+                .set("/name", "Bob")
+                .replace("/age", 21)
+                .increment("/score", 1)
+                .remove("/unused");
+
+        var copied = operations.copy();
+
+        assertThat(copied).isNotSameAs(operations);
+        assertThat(copied.size()).isEqualTo(operations.size());
+        assertThat(copied.getPatchOperations()).isNotSameAs(operations.getPatchOperations());
+    }
+
+    static class DummyPojo {
+        String name;
+        int age;
+
+        DummyPojo(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
 }


### PR DESCRIPTION
 ### Background

Implements bulk patch update support for CosmosDB, PostgreSQL, and MongoDB.

  ### What’s changed

  #### 1. New bulkPatch API

  - Added two bulk patch methods in CosmosDatabase:
      - bulkPatch(String coll, List<String> ids, PatchOperations operations, String partition)
      - bulkPatch(String coll, List<BulkPatchOperation> data, String partition)
  - Added BulkPatchOperation DTO (id + PatchOperations).
  - Added PatchOperations.copy() to safely duplicate operations when needed.

  #### 2. CosmosDB implementation

  - Implemented both bulkPatch methods in CosmosDatabaseImpl.
  - Uses chunked bulk execution (CosmosLimits.BULK_CHUNK_SIZE) with executeBulkWithRetry.
  - Aggregates results into CosmosBulkResult.successList / fatalList / retryList.
  - Added input validation for bulkPatch data.

  #### 3. PostgreSQL implementation

  - Implemented both bulkPatch methods in PostgresDatabaseImpl.
  - Added SQL-based chunk patching in TableUtil.bulkPatchRecords(...) for same-operations mode.
  - Per-item mode applies patch per operation and collects per-id success/failure.
  - Explicit maxRetries = 0 at wrapper level with comments:
      - avoids retrying non-idempotent patch operations (e.g., increment)
      - avoids duplicate application / incorrect success-failure classification

  #### 4. MongoDB implementation

  - Implemented both bulkPatch methods in MongoDatabaseImpl.
  - For result classification accuracy, uses per-id updateOne and classifies each id into:
      - successList when matched
      - fatalList when unmatched/failed
  - Added inline comments explaining trade-off vs bulkWrite (classification correctness over fewer round trips).

  #### 5. Docs

  - Updated README.md with a new Bulk Patch section:
      - same-operations usage
      - per-item usage
      - CosmosBulkResult behavior (successList, fatalList)

  ### Tests

  Added/updated tests for validation and behavior:

  - Validation tests:
      - CosmosDatabaseImplBulkPatchTest
      - PostgresDatabaseImplBulkPatchTest
      - MongoDatabaseImplBulkPatchTest
  - Behavior tests (missing-id classification + successful patch):
      - CosmosDatabaseImplTest
      - PostgresDatabaseImplTest
      - MongoDatabaseImplTest
  - Also updated PatchOperationsTest.

  ### Notes

  - Bulk patch is non-transactional.
  - Classification semantics are now explicitly tested for existing + non-existing ids across all three backends.
