### PR TITLE
feat: add method for easy logging db-specific query sql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.github.thunderz99</groupId>
     <artifactId>java-cosmos</artifactId>
     <packaging>jar</packaging>
-    <version>0.8.26</version>
+    <version>0.8.27.RC1</version>
     <name>${project.groupId}:${project.artifactId}$</name>
     <description>A lightweight Azure CosmosDB client for Java</description>
     <url>https://github.com/thunderz99/java-cosmos</url>

--- a/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
+++ b/src/main/java/io/github/thunderz99/cosmos/CosmosDatabase.java
@@ -6,6 +6,7 @@ import io.github.thunderz99.cosmos.condition.Aggregate;
 import io.github.thunderz99.cosmos.condition.Condition;
 import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
 import io.github.thunderz99.cosmos.dto.CosmosBulkResult;
+import io.github.thunderz99.cosmos.dto.CosmosSqlQuerySpec;
 import io.github.thunderz99.cosmos.dto.PartialUpdateOption;
 import io.github.thunderz99.cosmos.v4.PatchOperations;
 
@@ -233,6 +234,24 @@ public interface CosmosDatabase {
 
     public CosmosDocumentList find(String coll, Condition cond, String partition) throws Exception;
 
+    /**
+     * Generate a database-specific query spec for diagnostics such as slow query logs.
+     *
+     * <p>
+     * The default implementation returns the Cosmos DB SQL representation for backward
+     * compatibility. Database implementations with a different runtime dialect should override
+     * this method.
+     * </p>
+     *
+     * @param coll collection name
+     * @param cond condition to find
+     * @param partition partition name
+     * @return query spec in the runtime database dialect
+     */
+    default public CosmosSqlQuerySpec toQuerySpecForFind(String coll, Condition cond, String partition) {
+        return (cond == null ? Condition.filter() : cond).toQuerySpec();
+    }
+
 
 
 
@@ -316,6 +335,19 @@ public interface CosmosDatabase {
     public CosmosDocumentList aggregate(String coll, Aggregate aggregate, Condition cond, String partition) throws Exception;
 
     /**
+     * Generate a database-specific aggregate query spec for diagnostics such as slow query logs.
+     *
+     * @param coll collection name
+     * @param aggregate Aggregate function and groupBys
+     * @param cond condition to aggregate
+     * @param partition partition name
+     * @return aggregate query spec in the runtime database dialect
+     */
+    default public CosmosSqlQuerySpec toQuerySpecForAggregate(String coll, Aggregate aggregate, Condition cond, String partition) {
+        return (cond == null ? Condition.filter() : cond).toQuerySpecForAggregate(aggregate);
+    }
+
+    /**
      * do an aggregate query by Aggregate and empty condition
      * <p>
      * {@code
@@ -381,6 +413,18 @@ public interface CosmosDatabase {
      */
 
     public int count(String coll, Condition cond, String partition) throws Exception;
+
+    /**
+     * Generate a database-specific count query spec for diagnostics such as slow query logs.
+     *
+     * @param coll collection name
+     * @param cond condition to count
+     * @param partition partition name
+     * @return count query spec in the runtime database dialect
+     */
+    default public CosmosSqlQuerySpec toQuerySpecForCount(String coll, Condition cond, String partition) {
+        return (cond == null ? Condition.filter() : cond).toQuerySpecForCount();
+    }
 
     /**
      * Increment a number field of a document using json path format(e.g. "/count")

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImpl.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/PostgresDatabaseImpl.java
@@ -7,6 +7,7 @@ import io.github.thunderz99.cosmos.condition.Aggregate;
 import io.github.thunderz99.cosmos.condition.Condition;
 import io.github.thunderz99.cosmos.dto.BulkPatchOperation;
 import io.github.thunderz99.cosmos.dto.CosmosBulkResult;
+import io.github.thunderz99.cosmos.dto.CosmosSqlQuerySpec;
 import io.github.thunderz99.cosmos.dto.PartialUpdateOption;
 import io.github.thunderz99.cosmos.impl.postgres.dto.QueryContext;
 import io.github.thunderz99.cosmos.impl.postgres.util.PGAggregateUtil;
@@ -594,6 +595,17 @@ public class PostgresDatabaseImpl implements CosmosDatabase {
 
     }
 
+    @Override
+    public CosmosSqlQuerySpec toQuerySpecForFind(String coll, Condition cond, String partition) {
+        if (cond == null) {
+            cond = new Condition();
+        }
+        if (StringUtils.isEmpty(cond.collate)) {
+            cond.collate = ((PostgresImpl) cosmosAccount).collate;
+        }
+        return PGConditionUtil.toQuerySpec(coll, cond, partition);
+    }
+
     /**
      * find data by condition to iterator and return a CosmosDocumentIterator instead of a list.
      * Using this iterator can suppress memory consumption compared to the normal find method, when dealing with large data(size over 1000).
@@ -747,6 +759,15 @@ public class PostgresDatabaseImpl implements CosmosDatabase {
         return new CosmosDocumentList(maps);
     }
 
+    @Override
+    public CosmosSqlQuerySpec toQuerySpecForAggregate(String coll, Aggregate aggregate, Condition cond, String partition) {
+        if (cond == null) {
+            cond = new Condition();
+        }
+        var queryContext = QueryContext.create().databaseImpl(this);
+        return PGConditionUtil.toQuerySpec4Aggregate(coll, cond, aggregate, partition, queryContext);
+    }
+
     /**
      * Count data by condition(ignores offset and limit)
      * <p>
@@ -793,6 +814,14 @@ public class PostgresDatabaseImpl implements CosmosDatabase {
                 return count;
             }
         });
+    }
+
+    @Override
+    public CosmosSqlQuerySpec toQuerySpecForCount(String coll, Condition cond, String partition) {
+        if (cond == null) {
+            cond = new Condition();
+        }
+        return PGConditionUtil.toQuerySpecForCount(coll, cond, partition);
     }
 
     /**

--- a/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/PGConditionUtil.java
+++ b/src/main/java/io/github/thunderz99/cosmos/impl/postgres/util/PGConditionUtil.java
@@ -89,6 +89,7 @@ public class PGConditionUtil {
         // offset and limit
         queryText.append(String.format(" OFFSET %d LIMIT %d", cond.offset, cond.limit));
 
+        logPostgresQuery(queryText);
         return new CosmosSqlQuerySpec(queryText.toString(), params);
 
     }
@@ -252,6 +253,7 @@ public class PGConditionUtil {
             params = filterQueryAgg.params;
         }
 
+        logPostgresQuery(queryText);
         return new CosmosSqlQuerySpec(queryText.toString(), params);
 
     }
@@ -533,8 +535,23 @@ public class PGConditionUtil {
         // offset and limit
         // not needed for count
 
+        logPostgresQuery(queryText);
         return new CosmosSqlQuerySpec(queryText.toString(), params);
 
+    }
+
+    /**
+     * log the query text for pg at info level
+     *
+     * <p>
+     *     we may change the log level to trace in the future, if this is too noisy
+     * </p>
+     * @param queryText
+     */
+    static void logPostgresQuery(CharSequence queryText) {
+        if (log.isInfoEnabled()) {
+            log.info("postgresQueryText:{}", queryText);
+        }
     }
 
 
@@ -810,4 +827,3 @@ public class PGConditionUtil {
     }
 
 }
-

--- a/src/test/java/io/github/thunderz99/cosmos/impl/postgres/util/PGConditionUtilTest.java
+++ b/src/test/java/io/github/thunderz99/cosmos/impl/postgres/util/PGConditionUtilTest.java
@@ -76,6 +76,65 @@ class PGConditionUtilTest {
         }
     }
 
+    @Test
+    void postgresDatabase_toQuerySpecForFind_should_return_postgres_sql() throws Exception {
+        if (PostgresDatabaseImplTest.db == null) {
+            PostgresDatabaseImplTest.beforeAll();
+        }
+
+        var cond = Condition.filter("age", 18)
+                .fields("id", "name")
+                .sort("name", "ASC");
+
+        var querySpec = PostgresDatabaseImplTest.db.toQuerySpecForFind("schema1", cond, "table1");
+
+        var expectedSQL = """
+                SELECT id,
+                jsonb_build_object('id', data->'id', 'name', data->'name') AS "data"
+                
+                 FROM schema1.table1
+                 WHERE (NULLIF(data->>'age','')::numeric = @param000_age)
+                 ORDER BY data->>'name' COLLATE "C" ASC, data->>'_ts' ASC, id COLLATE "C" ASC OFFSET 0 LIMIT 100
+                """;
+        assertThat(querySpec.getQueryText()).isEqualTo(expectedSQL.trim());
+        assertThat(querySpec.getParameters()).containsExactly(new CosmosSqlParameter("@param000_age", 18));
+    }
+
+    @Test
+    void postgresDatabase_toQuerySpecForCount_should_return_postgres_sql() throws Exception {
+        if (PostgresDatabaseImplTest.db == null) {
+            PostgresDatabaseImplTest.beforeAll();
+        }
+
+        var cond = Condition.filter("age", 18);
+        var querySpec = PostgresDatabaseImplTest.db.toQuerySpecForCount("schema1", cond, "table1");
+
+        assertThat(querySpec.getQueryText())
+                .isEqualTo("SELECT COUNT(*) FROM schema1.table1 WHERE (NULLIF(data->>'age','')::numeric = @param000_age)");
+        assertThat(querySpec.getParameters()).containsExactly(new CosmosSqlParameter("@param000_age", 18));
+    }
+
+    @Test
+    void postgresDatabase_toQuerySpecForAggregate_should_return_postgres_sql() throws Exception {
+        if (PostgresDatabaseImplTest.db == null) {
+            PostgresDatabaseImplTest.beforeAll();
+        }
+
+        var aggregate = Aggregate.function("COUNT(1) AS facetCount").groupBy("formId");
+        var cond = Condition.filter("formId IN", List.of("id1", "id2"));
+        var querySpec = PostgresDatabaseImplTest.db.toQuerySpecForAggregate("schema1", aggregate, cond, "table1");
+
+        var expectedSQL = """
+                SELECT COUNT(1) AS "facetCount", data->>'formId' AS "formId"
+                 FROM schema1.table1
+                 WHERE (data->>'formId' = ANY(@param000_formId))
+                 GROUP BY data->>'formId'
+                 OFFSET 0 LIMIT 100
+                """;
+        assertThat(querySpec.getQueryText()).isEqualTo(expectedSQL.trim());
+        assertThat(querySpec.getParameters()).containsExactly(new CosmosSqlParameter("@param000_formId", List.of("id1", "id2")));
+    }
+
 
     @Test
     void generateFilterQuery_should_work() {


### PR DESCRIPTION
 When developers using java-cosmos to run against PostgreSQL in a local development environment, database query logs currently show the Cosmos DB SQL generated from `Condition`, even though the actual runtime database is PostgreSQL.

  This is misleading for developers because the logged SQL does not match the SQL/jsonb query executed against the local PostgreSQL database. As a result, developers cannot reliably copy the logged query for debugging, performance investigation, or manual verification in the local database.

  This PR is needed to expose database-specific query-spec generation APIs and make the PostgreSQL implementation return PostgreSQL/jsonb SQL for find, count, and aggregate queries. With this change, logs can correctly show the actual PostgreSQL query text when the application is using PostgreSQL, while preserving the existing Cosmos DB behavior for Cosmos environments.